### PR TITLE
feat: improve github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: write
+  actions: read
+
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
@@ -44,9 +48,17 @@ jobs:
       run: |
         go mod download
         
-        # Build for Linux (amd64)
+        # Build for Linux (amd64 & arm64)
         GOOS=linux GOARCH=amd64 go build -o notificator-linux-amd64 .
-    
+        GOOS=linux GOARCH=arm64 go build -o notificator-linux-arm64 .
+
+        # Build for macOS (amd64 & arm64)
+        GOOS=darwin GOARCH=amd64 go build -o notificator-macos-amd64 .
+        GOOS=darwin GOARCH=arm64 go build -o notificator-macos-arm64 .
+
+        # Build for Windows (amd64)
+        GOOS=windows GOARCH=amd64 go build -o notificator-windows-amd64.exe .
+
     - name: Create and push tag
       run: |
         git config --local user.email "action@github.com"
@@ -68,11 +80,19 @@ jobs:
           ## Changes
           - Built from commit: ${{ github.sha }}
           - Automatic release triggered by push to master
-          
+
           ## Binaries
           Multiple platform binaries are attached to this release:
           - `notificator-linux-amd64` - Linux x86_64
+          - `notificator-linux-arm64` - Linux ARM64
+          - `notificator-macos-amd64` - macOS x86_64
+          - `notificator-macos-arm64` - macOS ARM64
+          - `notificator-windows-amd64.exe` - Windows x86_64
         draft: false
         prerelease: false
         files: |
           notificator-linux-amd64
+          notificator-linux-arm64
+          notificator-macos-amd64
+          notificator-macos-arm64
+          notificator-windows-amd64.exe


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/release.yml` to enhance the release process by adding support for multiple platforms and architectures, as well as adjusting permissions for the workflow. The most important changes include enabling multi-platform binary builds, updating release notes and attached files, and setting specific permissions for the workflow.

### Multi-platform support for binary builds:

* Added build steps for `arm64` architecture on Linux and macOS, as well as `amd64` architecture on macOS and Windows. This ensures binaries are built for Linux (`amd64` and `arm64`), macOS (`amd64` and `arm64`), and Windows (`amd64`).

### Release notes and attached files:

* Updated release notes to include descriptions of the newly added binaries for each platform and architecture. Added these binaries to the list of files attached to the release.

### Workflow permissions:
* Added `permissions` configuration to the workflow, granting `write` access to contents and `read` access to actions. This ensures the workflow has the necessary permissions to perform release-related tasks.