### PR TITLE
fix: using default endpoint defined in config/oauth_config.go

### DIFF
--- a/internal/backend/services/oauth_service.go
+++ b/internal/backend/services/oauth_service.go
@@ -11,9 +11,6 @@ import (
 	"time"
 
 	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/github"
-	"golang.org/x/oauth2/google"
-	"golang.org/x/oauth2/microsoft"
 
 	"notificator/config"
 	"notificator/internal/backend/database"
@@ -92,7 +89,10 @@ func (s *OAuthService) initializeProviders() error {
 			ClientID:     provider.ClientID,
 			ClientSecret: provider.ClientSecret,
 			Scopes:       provider.Scopes,
-			Endpoint:     s.getOAuthEndpoint(name, provider),
+			Endpoint:     oauth2.Endpoint{
+				AuthURL:  provider.AuthURL,
+				TokenURL: provider.TokenURL,
+			},
 			RedirectURL:  fmt.Sprintf("%s/%s/callback", s.config.RedirectURL, name),
 		}
 
@@ -105,22 +105,6 @@ func (s *OAuthService) initializeProviders() error {
 	}
 
 	return nil
-}
-
-func (s *OAuthService) getOAuthEndpoint(name string, provider config.OAuthProvider) oauth2.Endpoint {
-	switch name {
-	case "github":
-		return github.Endpoint
-	case "google":
-		return google.Endpoint
-	case "microsoft":
-		return microsoft.AzureADEndpoint("")
-	default:
-		return oauth2.Endpoint{
-			AuthURL:  provider.AuthURL,
-			TokenURL: provider.TokenURL,
-		}
-	}
 }
 
 func (s *OAuthService) GetAuthURL(provider, state string) (string, error) {


### PR DESCRIPTION
This pull request refactors how OAuth endpoints are configured in the `OAuthService`. Instead of relying on provider-specific imports and logic, the code now uses the endpoint URLs provided in the configuration, simplifying the setup and making it more flexible for additional providers.

**OAuth provider configuration simplification:**

* Removed imports for provider-specific OAuth endpoints (`github`, `google`, `microsoft`) from `internal/backend/services/oauth_service.go`, reducing dependency on external libraries for endpoint definitions.
* Updated the provider initialization to directly use `AuthURL` and `TokenURL` from the configuration, instead of calling a helper method to select the endpoint.
* Removed the `getOAuthEndpoint` method and its provider-specific logic, streamlining the code and making it easier to add new OAuth providers.