### PR TITLE
feat: allow for objects in env

### DIFF
--- a/charts/notificator-app/templates/backend-deployment.yaml
+++ b/charts/notificator-app/templates/backend-deployment.yaml
@@ -55,7 +55,11 @@ spec:
         # Custom environment variables from values.yaml
         {{- range $key, $value := .Values.backend.env }}
         - name: {{ $key }}
+          {{- if kindIs "string" $value }}
           value: {{ $value | quote }}
+          {{- else }}
+            {{- toYaml $value | nindent 10 }}
+          {{- end }}
         {{- end }}
         
         # Global settings (can be overridden by backend.env)

--- a/charts/notificator-app/templates/webui-deployment.yaml
+++ b/charts/notificator-app/templates/webui-deployment.yaml
@@ -54,7 +54,11 @@ spec:
         # Custom environment variables from values.yaml
         {{- range $key, $value := .Values.webui.env }}
         - name: {{ $key }}
+          {{- if kindIs "string" $value }}
           value: {{ $value | quote }}
+          {{- else }}
+            {{- toYaml $value | nindent 10 }}
+          {{- end }}
         {{- end }}
         
         # Backend connection (can be overridden by webui.env)


### PR DESCRIPTION
That way the user can use stuff like `valueFrom.secretKeyRef` and such
