### PR TITLE
docs: add OpenWiki documentation set

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+## OpenWiki
+
+This repository has documentation located in the /openwiki directory.
+
+Start here:
+- [OpenWiki quickstart](openwiki/quickstart.md)
+
+OpenWiki includes repository overview, architecture notes, workflows, domain concepts, operations, integrations, testing guidance, and source maps.
+
+When working in this repository, read the OpenWiki quickstart first, then follow its links to the relevant architecture, workflow, domain, operation, and testing notes.

--- a/openwiki/.last-update.json
+++ b/openwiki/.last-update.json
@@ -1,0 +1,6 @@
+{
+  "updatedAt": "2026-07-07T10:09:14.000Z",
+  "command": "update",
+  "gitHead": "ba5a4442821985280cb4f5234e6f027348332947",
+  "model": "claude-opus-4-8"
+}

--- a/openwiki/architecture.md
+++ b/openwiki/architecture.md
@@ -1,0 +1,97 @@
+# Architecture
+
+Notificator is a Go monorepo that builds into **one binary with subcommands**. The supported
+deployment runs two of those subcommands as separate processes plus a database.
+
+## Components and ports
+
+| Component | Command | Listens | Talks to |
+|-----------|---------|---------|----------|
+| **Backend** | `notificator backend` | gRPC `:50051`, HTTP `:8080` (`/health`, `/metrics`) | Database (SQLite/Postgres) |
+| **WebUI** | `notificator webui` | HTTP `:8081` | Backend (gRPC), Alertmanager(s) (HTTP poll) |
+| Alertmanager(s) | external | `:9093` (convention) | — |
+| Database | external | Postgres `:5432` or embedded SQLite | — |
+
+The browser only ever talks to the WebUI. The WebUI is a **gRPC client** of the backend; the
+backend is the only process with database access. Entrypoints:
+`main.go` → `cmd.Execute()` (`cmd/root.go:25`) → `runBackend` (`cmd/backend.go:41`) /
+`runWebUI` (`cmd/webui.go:39`).
+
+```
+                 ┌────────────────────────┐
+ Browser ◄──────►│  WebUI  (:8081)        │
+  HTTP + SSE     │  Gin + templ + HTMX    │
+                 │  + Alpine.js           │
+                 └───┬───────────────┬────┘
+              gRPC   │               │ HTTP poll (every ~10s)
+                     ▼               ▼
+        ┌────────────────────┐   ┌──────────────────┐
+        │ Backend (:50051)   │   │ Alertmanager(s)  │
+        │ AuthService        │   │  /api/v2/alerts  │
+        │ AlertService       │   └──────────────────┘
+        │ StatisticsService  │
+        └─────────┬──────────┘
+                  ▼
+        ┌────────────────────┐
+        │ SQLite / Postgres  │
+        └────────────────────┘
+```
+
+## Request flow (a browser hit)
+
+1. Gin middleware chain runs: `CORSMiddleware` → `LoggingMiddleware` → `gin.Recovery` →
+   `SessionMiddleware` (`internal/webui/router.go:130-134`).
+2. Route-group auth wrappers (`RequireAuth` / `OptionalAuth` / `RedirectIfNotAuth`) call
+   `backendClient.ValidateSession(sessionID)` — **a gRPC round-trip on every request**, no
+   local session cache (`internal/webui/middleware/auth.go`).
+3. The handler either renders a `templ` component to the response writer, or translates the
+   HTTP request into a backend gRPC call and marshals the proto reply back to JSON / templ props.
+4. Handlers reach their dependencies (backend client, alert cache, services) through
+   **package-level singletons** set once at startup via `handlers.Set*` functions
+   (`internal/webui/handlers/handlers.go`), not per-request injection.
+
+Details: [webui](webui.md) and [backend](backend.md).
+
+## Real-time — two distinct mechanisms {#real-time}
+
+Notificator has **two independent real-time paths**; do not conflate them.
+
+**1. Live alerts → browser (SSE, polling-backed).** The WebUI owns an in-memory
+`AlertCache` (`internal/webui/services/alert_cache.go`) that polls Alertmanager every
+~10s (`Polling.SyncInterval`), diffs the result, and fans changes out to browsers over
+**Server-Sent Events** (`GET /api/v1/dashboard/stream`, `internal/webui/handlers/sse_handler.go`).
+Subscriber channels are buffered and **non-blocking** — a slow browser silently misses
+updates rather than stalling the poll loop. The backend is *not* in this path.
+
+**2. Collaboration updates (backend gRPC streaming).** The backend exposes
+`SubscribeToAlertUpdates` (server-streaming gRPC, `internal/backend/services/services.go`),
+an **in-memory pub/sub keyed per alert key**. Mutating RPCs (add comment/ack, resolve)
+broadcast to subscribers after the DB write. Because subscriptions live in process memory,
+**this only works with a single backend replica** — there is no Redis/NATS fan-out.
+
+As a side effect of path 1, when the alert cache sees an alert appear/resolve it
+fire-and-forgets statistics events to the backend (`CaptureAlertFired`,
+`UpdateAlertResolved`) and archives fully-resolved alerts with their comments/acks.
+
+## Build variants and tags {#build-variants}
+
+The single `main.go` compiles into different command sets via Go build tags:
+
+| Build command | Commands present | Used for |
+|---------------|------------------|----------|
+| `go build .` (no tags) | `backend` only | — (default build is not useful on its own) |
+| `go build -tags nogui .` | `backend`, `desktop` (error stub) | `Dockerfile.backend` |
+| `go build -tags "nogui,webui" .` | `backend`, `webui`, `desktop` (stub) | `Dockerfile.webui` |
+
+Tag gates: `cmd/backend.go` + `cmd/root.go` have **no tag** (always built);
+`cmd/webui.go` requires `//go:build webui`; `cmd/desktop_stub.go` requires `//go:build nogui`
+and only registers a `desktop` command that prints "not available" and exits.
+
+> **There is no working desktop GUI in this checkout.** No non-stub `desktop.go` exists in
+> `cmd/`. `cmd/root.go:36-38` still defaults dispatch to `"desktop"` and the `Makefile` still
+> has `go-*-desktop` targets, but they resolve to the error stub (or "unknown command" in a
+> plain build). The Fyne desktop app has effectively been removed; the leftover Fyne-dependent
+> packages (`internal/notifier`, `internal/audio`), `FyneApp.toml`, and the `fyne.io/fyne/v2`
+> dependency are **dead code slated for cleanup**. Treat backend + webui as the whole product.
+
+CGO is enabled in both Docker images for SQLite support. See [operations](operations.md).

--- a/openwiki/backend.md
+++ b/openwiki/backend.md
@@ -1,0 +1,115 @@
+# Backend
+
+The backend (`notificator backend`, `internal/backend/`) is the system's single source of
+truth: it owns the database, authentication, alert-collaboration state, and the statistics
+engine. Everything is exposed over **gRPC** on `:50051`; a small plain-HTTP server on `:8080`
+serves only `/health` and `/metrics`.
+
+## Bootstrap
+
+`Server.Start()` (`internal/backend/server.go:48`) does, in order: init DB → `AutoMigrate` →
+`initServices()` → start gRPC → start HTTP → start two background cleanup tickers → block on
+graceful shutdown. gRPC registers three services plus reflection (grpcurl-friendly):
+
+| Service | Impl | Proto |
+|---------|------|-------|
+| `AuthService` | `AuthServiceGorm` | `proto/auth.proto` |
+| `AlertService` | `AlertServiceGorm` | `proto/alert.proto` |
+| `StatisticsService` | `StatisticsServiceGorm` | `proto/alert.proto` |
+
+`OAuthService` is initialized only when `config.OAuth.Enabled`. Statistics capture is offloaded
+to a `StatisticsWorkerPool` (10 workers, queue 1000; `server.go:131`). A single
+`grpc.UnaryInterceptor` logs method/duration/status (its `getClientIP` is a stub that always
+returns `"unknown"`).
+
+## Authentication & sessions {#auth}
+
+The entire auth model is: **every RPC takes a `session_id` string and calls
+`db.GetUserBySession(sessionId)`** (`internal/backend/database/gorm_db.go`, joins
+`sessions.expires_at > now()`). Key consequences:
+
+- **No auth interceptor.** Each handler validates the session by hand. A new RPC that forgets
+  the check has *no* auth. This is the single most important thing to know before adding an RPC.
+- `Login` creates a bcrypt-checked `User` session with a random hex `session_id`, 7-day expiry
+  (`internal/backend/services/services.go`). `User` supports both local password and OAuth
+  identity (`OAuthProvider`/`OAuthID`, `internal/backend/models/models.go`).
+- **No enforced RBAC.** `models/oauth_models.go` defines `UserRole` and OAuth group-sync
+  machinery, but nothing gates an RPC by role. `GetConnectedUsers` is commented "admin only"
+  yet only checks that *some* valid session exists. Do not trust "admin only" comments.
+
+## Database
+
+GORM over **SQLite or PostgreSQL**, selected by `config.Backend.Database.Type` (or the
+`--db-type` flag). `NewGormDB` (`database/gorm_db.go:27`) picks the dialect; dialect-specific
+SQL is guarded by `IsSQLite()` / `IsPostgreSQL()`.
+
+`AutoMigrate()` runs `RunCustomMigrations()` **first** (`database/migrate.go`: dedupe
+`alert_statistics` before adding a unique index, add `column_configs` to `filter_presets`,
+create `user_column_preferences`, backfill `fix_time_seconds`), then GORM `AutoMigrate` over
+~20 models: users, sessions, comments, acknowledgments, resolved_alerts, notification prefs,
+hidden alerts/rules, filter presets, the full OAuth table set, Sentry config, alert statistics
++ aggregates, statistics views, annotation-button configs. On Postgres it additionally creates
+GIN indexes on `alert_statistics.metadata` (best-effort — failure only warns).
+
+**Two independent expiry mechanisms** (don't confuse them when debugging "my data vanished"):
+
+- **Resolved-alert TTL** — `ResolvedAlert.ExpiresAt = now + ttlHours` (default 24h if the caller
+  omits it). Reads filter `expires_at > now()`; an hourly job physically deletes expired rows
+  (`server.go` `performResolvedAlertCleanup`).
+- **Statistics retention** — `alert_statistics` rows older than `config.Statistics.RetentionDays`
+  (default 90d) are purged daily (`server.go` statistics cleanup).
+
+## Statistics engine
+
+This is the largest backend subsystem. See [domain concepts](domain.md#statistics) for the
+metric definitions (MTTR / MTTA / fix-time / on-call rules).
+
+- **Capture** (`services/statistics_capture.go`): `CaptureAlertFired` upserts an
+  `AlertStatistic` keyed idempotently on `(fingerprint, fired_at)`. `UpdateAlertResolved` sets
+  `ResolvedAt` and computes **MTTR = resolved − fired** and **FixTime = resolved − acknowledged**.
+  `UpdateAlertAcknowledged` computes **MTTA = acknowledged − fired** and now writes it to the
+  `MTTASeconds` column (it previously mis-wrote MTTA into `MTTRSeconds` — a data-correctness bug,
+  now fixed). Capture also records `silenced_at_fire`, driving the `include_silenced` query filters.
+- **Async path** (`services/statistics_worker.go`): jobs run through the worker pool and are
+  **silently dropped if the queue (1000) is full** — only a warning is logged, no metric today.
+- **Query** (`services/statistics_query.go`): `QueryStatistics` filters by time range, optional
+  severity/team (multi-select OR), optional on-call time-of-day window, `include_silenced`, and an
+  explicit `timezone`, grouped by `severity | team | alert_name | period | none`. Two additional
+  analytics RPCs are **PostgreSQL-only** (they use `EXTRACT(DOW …)` / `array_agg` and error on
+  SQLite): **`QueryHeatmap`** (day-of-week × hour counts + avg MTTR, in the user's tz) and
+  **`QueryFlappingAlerts`** (fingerprints with `COUNT(*) ≥ min_fires`, default 3, scored by
+  fire-rate/gap). `QueryFlappingAlerts` is exposed at `/api/v1/statistics/flapping` but has **no
+  current UI** — see [statistics](statistics.md#metrics-and-charts).
+
+### On-call overlap filter (regression-sensitive)
+
+The most subtle code in the backend. The on-call time-of-day filter used to match on `fired_at`
+clock time only, which **dropped daytime-fired alerts that ran into the night window**. The fix
+treats each alert's **active interval `[fired_at, COALESCE(resolved_at, NOW())]`**
+and includes it if that interval *overlaps* any daily occurrence of the on-call window — with
+cross-midnight support (e.g. 18:00→08:00) and separate Postgres (`make_interval`) and SQLite
+(`julianday`/`strftime`) implementations (`statistics_query.go` `onCallOverlapClause`).
+`weekendMode` is `exclude | same_hours | full_weekends`.
+
+**`internal/backend/services/statistics_oncall_test.go` is the reference for the intended
+semantics — read it before touching the overlap clause.**
+
+## Real-time collaboration push
+
+`SubscribeToAlertUpdates` is a server-streaming RPC backed by an in-memory
+`subscriptions map[alertKey][]*Subscription` guarded by a mutex (`services/services.go`).
+Mutating RPCs call `broadcastUpdate` after a successful DB write; a failed `Stream.Send`
+auto-unsubscribes that client. Scoped **per alert key** (no global stream) and **single-process
+only** (no cross-replica fan-out). See [architecture](architecture.md#real-time).
+
+## Gotchas {#gotchas}
+
+- **No auth interceptor** — forgetting the per-RPC `session_id` check = an unauthenticated RPC.
+- **"Admin only" is not enforced** anywhere despite the `UserRole`/group infra existing.
+- **Dead code:** `services/comment_service.go` and `services/acknowledgment_service.go` define
+  `CommentService`/`AcknowledgmentService` whose constructors are never called — the real logic
+  is inline in `AlertServiceGorm`.
+- **Silent job drops:** statistics worker pool drops events when full, with no alerting.
+- **Single-replica constraint:** in-memory subscriptions break under horizontal scaling.
+- **Encryption key fallback:** Sentry token storage falls back to a hardcoded dev key if
+  `NOTIFICATOR_ENCRYPTION_KEY` is unset — see [configuration](configuration.md#sentry).

--- a/openwiki/configuration.md
+++ b/openwiki/configuration.md
@@ -1,0 +1,88 @@
+# Configuration
+
+Configuration is loaded by Viper (`config/config.go`, `LoadConfigWithViper`), wired up in
+`cmd/root.go:initConfig`. Precedence, highest to lowest:
+
+1. **Command-line flags** (e.g. `--db-type`, `--grpc-listen`)
+2. **Environment variables** (`NOTIFICATOR_*` prefix, plus a few legacy names)
+3. **`config.json`** (searched in `$HOME/.config/notificator`, `./config`, `.`)
+4. **Go struct defaults** (`DefaultConfig()`)
+
+`ENVIRONMENT_VARIABLES.md` in the repo root is the full env-var reference; this page is the map.
+
+## Env-var scheme
+
+`NOTIFICATOR_` + the JSON config path in upper snake case (dots → underscores):
+`backend.grpc_listen` → `NOTIFICATOR_BACKEND_GRPC_LISTEN`. Viper's `AutomaticEnv` binds most
+scalar fields automatically. A few legacy/plain names are also honored:
+`DATABASE_URL`, `DB_HOST`/`DATABASE_HOST`, `BACKEND_ADDRESS`, and the whole `OAUTH_*` family.
+
+## Config sections (`config.Config`, `config/config.go:15`)
+
+| Section | Purpose |
+|---------|---------|
+| `alertmanagers[]` | Alertmanager endpoints (name, url, auth, headers, oauth) — see below |
+| `backend` | `grpc_listen`, `grpc_client`, `http_listen`, `database{…}` |
+| `backend.database` | `type` (`sqlite`/`postgres`), host/port/name/user/password/ssl_mode, `sqlite_path` |
+| `webui` | `playground` toggle (dev landing page) |
+| `oauth` | OAuth portal config (nilable) — see [OAuth](#oauth) |
+| `sentry` | Sentry enrichment (nilable) — see [Sentry](#sentry) |
+| `admin` | `impersonation_allowed_users[]` — who may impersonate |
+| `resolved_alerts`, `statistics` | TTL / retention knobs (see [backend](backend.md#database)) |
+| `polling` | Alertmanager poll interval / sync interval |
+| `gui`, `notifications`, `column_widths` | ⚠️ **desktop-only, dead** — see [architecture](architecture.md#build-variants) |
+
+## Multi-Alertmanager & multi-tenant (Mimir/Cortex)
+
+Alertmanagers are **not** bound generically by Viper — they're read in a manual loop over
+`alertmanagers.0` … `alertmanagers.9` (`config.go:267`). Each entry becomes a `Client` in the
+`MultiClient` (`internal/alertmanager/client.go`), and results are tagged with the source name.
+`FetchAllAlerts` tolerates partial failures — it only errors if *every* Alertmanager fails.
+
+**Multi-tenancy is just custom HTTP headers**, injected by a `customHeaderRoundTripper` — there
+is no Mimir-specific code path. Two ways to set them:
+
+- **Per instance:** `NOTIFICATOR_ALERTMANAGERS_<N>_HEADERS="X-Scope-OrgID=prod-tenant"`
+  (comma-separated `Key=Val` pairs).
+- **Global:** `METRICS_PROVIDER_HEADERS="X-Scope-OrgID=your-tenant"`, merged into every
+  Alertmanager that doesn't already set the header (via `cfg.MergeHeaders()`).
+
+> ⚠️ `MergeHeaders()` is called in `cmd/backend.go` **and** `cmd/webui.go` startup paths — but
+> note it only fills headers not already set per-instance.
+
+Per-instance auth also supports basic auth (`username`/`password`), bearer `token`, and a
+proxy-auth mode (`oauth.proxy_mode`) for Alertmanagers behind an oauth2-proxy.
+
+## OAuth {#oauth}
+
+`OAuthPortalConfig` (`config/oauth_config.go`): `enabled`, `disable_classic_auth`,
+`redirect_url`, `session_key`, `providers{}`, `group_sync{}`, `security{}`.
+`loadOAuthProvidersFromEnv` auto-configures **github / google / microsoft / okta** from
+`OAUTH_<PROVIDER>_CLIENT_ID` / `_SECRET` (+ optional scopes/URLs), with sensible default
+endpoints and group mappings baked in. `Validate()` refuses to start if `session_key` is still
+the insecure default or if no enabled provider has credentials.
+
+Group sync (`OAUTH_GROUP_SYNC_*`) maps OAuth groups → roles with a cache (default 1h TTL) and a
+`default_role` (e.g. `viewer`). See `docs/oauth/` for provider setup walkthroughs and
+`docs/oauth/examples/config-examples.json`.
+
+> **Reminder:** roles are computed and stored, but **no RPC actually enforces them** today
+> (see [backend](backend.md#auth)).
+
+## Sentry {#sentry}
+
+`SentryConfig{Enabled, BaseURL, GlobalToken}` (`NOTIFICATOR_SENTRY_*`). Per-user Sentry personal
+tokens are stored **AES-256-GCM encrypted** (`internal/backend/database/sentry_db.go`); at query
+time the WebUI resolves the user's own token → the admin `GlobalToken` fallback → none, and
+enriches alerts from Sentry issue URLs found in annotations/labels.
+
+> ⚠️ **Security gotcha:** the encryption key comes from `NOTIFICATOR_ENCRYPTION_KEY`, but falls
+> back to a **hardcoded dev key** if unset — and this var is **not** documented in
+> `ENVIRONMENT_VARIABLES.md` or `.env.example`. Set it in any real deployment that stores Sentry
+> tokens, or those tokens are encrypted with a publicly-known key.
+
+## Session secret
+
+`NOTIFICATOR_SESSION_SECRET` (documented in `.env.example`, generate with `openssl rand -hex 32`)
+signs the WebUI session cookie. If unset, the WebUI uses a **random per-process secret**, so
+sessions don't survive a restart (see [webui](webui.md#auth)).

--- a/openwiki/dashboard.md
+++ b/openwiki/dashboard.md
@@ -1,0 +1,193 @@
+# Live Alert Dashboard
+
+The live dashboard (`/dashboard`) is the app's primary operational surface: the real-time table
+of firing alerts with acknowledge / comment / silence / hide actions. This page documents its
+internals. For the page's place in the wider system see [webui](webui.md); for the alert-cache /
+SSE plumbing it rides on see [architecture](architecture.md#real-time).
+
+**Source:** page `internal/webui/templates/pages/NewDashboard.templ`; logic in
+`internal/webui/templates/scripts/dashboard_*.templ`; server in
+`internal/webui/handlers/dashboard_handlers.go`. Never edit `*_templ.go` — see
+[operations](operations.md#codegen).
+
+## Client architecture: one component + manual mixins
+
+The whole page is a single Alpine component, `newDashboard()`
+(`scripts/dashboard_core.templ:5`), mounted with `x-data` on the outer div
+(`NewDashboard.templ:14`). Its logic is split across script files that each attach methods to a
+`window.dashboard*Mixin` global; `init()` merges them onto the one instance with
+`Object.assign(this, window.dashboardDataMixin || {})` etc. (`dashboard_core.templ:287`). This is
+a **hand-rolled mixin pattern, not an Alpine plugin.**
+
+The scripts included at the bottom of the page (`NewDashboard.templ:986`):
+`NotificationService`, `DashboardFilterPresetsMixin`, `DashboardResolvedAlertsMixin`,
+`DashboardCore`, `DashboardData`, `DashboardActions`, `DashboardUtilities`, `DashboardModal`,
+`DashboardSettings`.
+
+`init()` (`dashboard_core.templ:287`) also sets **`window.dashboardInstance = this`** — a
+load-bearing global that modals, dropdowns, the Sentry loader, and the logout handler all reach
+into. Removing it silently breaks unrelated features. `init()` further installs a `fetch`
+interceptor that redirects to `/login` on any 401, tracks first-load state in `sessionStorage`,
+loads settings/columns/user/annotation-buttons, applies a default filter preset **or** URL
+filters, starts SSE (or polling), and opens the alert modal if the URL is `/dashboard/alert/:id`.
+
+## Data lifecycle
+
+### Full load
+
+`loadDashboardData()` (`scripts/dashboard_data.templ:6`) → `GET /api/v1/dashboard/data` →
+`GetDashboardData` (`dashboard_handlers.go:112`). The server reads from the in-memory
+**`alertCache`** (not a per-request Alertmanager call — see [webui](webui.md#alert-cache)); the
+subset depends on `displayMode`:
+
+| `displayMode` | Source |
+|---------------|--------|
+| `classic` | cached alerts that are **not** acknowledged and **not** resolved |
+| `acknowledge` | acknowledged alerts |
+| `resolved` | statistics "recently resolved" (see [statistics](statistics.md)) |
+| `hidden` / `full` | active + resolved combined |
+
+The server then applies filters (`applyDashboardFilters`, `dashboard_handlers.go:356`), sorting,
+pagination, and either flat-list or group-by rendering. Filter **dropdown option lists** and
+counters (`buildDashboardMetadata:628`) are computed from the *full* alert set for that display
+mode, not the filtered page — so dropdowns don't shrink as you filter (intentional, looks like a
+bug but isn't).
+
+### Live updates (SSE) and the client-side merge
+
+`initSSE()` (`dashboard_core.templ:458`) opens `EventSource('/api/v1/dashboard/stream')`; `update`
+events go to `applyIncrementalUpdate()`. Server side, `SSEStream`
+(`internal/webui/handlers/sse_handler.go:25`) subscribes to `alertCache.Subscribe()` and forwards
+each change plus a 30s `ping`. On SSE error the client falls back to polling
+`/api/v1/dashboard/incremental`. Both paths converge on **one merge function**,
+`applyIncrementalUpdate(update, source)` — the `source` (`'sse'` vs `'poll'`) matters: on the SSE
+path (genuine Alertmanager resolves) it evicts removed fingerprints from the notification seen-set
+so re-fires re-notify; the poll path does not, because its `removedAlerts` conflate resolve with
+filter-out. See [notifications](notifications.md#what-triggers-a-notification).
+
+> ⚠️ **SSE broadcasts unfiltered, colorless data to every subscriber.** The server does no
+> per-user filtering on the SSE path (unlike the polling path). Therefore the client re-applies
+> filters itself via **`alertMatchesFilters()`** (`dashboard_data.templ:421`) — a full JS
+> reimplementation of the server's `applyDashboardFilters`. **These two must be kept in sync:**
+> any new server-side filter dimension that isn't mirrored in `alertMatchesFilters` silently
+> breaks live updates for that filter. Colors aren't in SSE payloads either, so the client
+> debounces a `loadAlertColors(true)` refetch after an SSE update — but the **initial** full-load
+> response now embeds a `colors` map (`GetDashboardData` → `response.Colors`, applied before
+> `this.alerts` is set), fixing first-paint color lag; the standalone `GET /alert-colors` endpoint
+> remains as a fallback.
+
+**Adaptive polling** (only when not on SSE, `dashboard_core.templ:506`): every 10 polls it slows
+toward 60s if <10% of polls saw changes, or speeds toward 5s if >50% did.
+
+## Filtering and grouping
+
+Filter dimensions: free-text `searchQuery`; multi-select `severities`, `statuses`, `teams`,
+`alertmanagers`, `alertNames`. Filtering runs **on both sides** — server for the authoritative
+page, client for SSE/incremental merges.
+
+> The **acknowledged / comments** checkbox filters were **removed from the UI** (their checkbox
+> values never matched the comparison code, and multi-checkbox-to-one-`x-model` is invalid Alpine).
+> The backend still parses `?acknowledged=` / `?hasComments=` in `applyDashboardFilters` — the
+> capability is dormant (unreachable from the UI) but intact if called directly.
+
+**Hidden alerts are two-tier:** global per-user hidden alerts/rules (via `hiddenAlertsService`,
+Settings → Hidden tab) *and* filter-scoped hides stored inside a filter preset's `filter_data`.
+See [domain](domain.md#collaboration-state-persisted-by-the-backend).
+
+**Grouping** (`viewMode = 'group'`) renders `AlertsGroupView`; the group-by field
+(`groupByLabel`, default `alertname`) is grouped server-side by `groupAlertsByLabel`
+(`dashboard_handlers.go:559`) — supports `alertname`/`severity`/`team`/`instance` plus any
+arbitrary label key (fallback bucket `"Other"`). Each group carries a `WorstSeverity`.
+
+## The dynamic table and configurable columns
+
+The table (`components/dynamic_alerts_table.templ`) is fully driven by `this.columns` /
+`this.visibleColumns`. Cells are rendered by `renderCell(alert, column)`
+(`dashboard_utilities.templ:655`), dispatching on `column.formatter`
+(`checkbox|text|badge|duration|timestamp|count|actions`) to functions that emit HTML strings
+inserted via `x-html`. `getFieldValue` resolves dotted `field_path` (e.g. `labels.environment`).
+
+11 default columns (`getDefaultColumns:639`). The Column Config modal
+(`components/column_config_modal.templ`) supports drag-reorder, visibility, width (50–800px),
+and creating **custom columns** backed by any label/annotation. Preferences persist via
+`GET/PUT /api/v1/dashboard/column-preferences`, and column configs can also travel inside a filter
+preset. Server validates configs (unique id/order, width bounds, allowed formatter/field_type) in
+`filter_preset_handlers.go:92`.
+
+## Alert actions
+
+Every single and bulk action funnels through **`POST /api/v1/dashboard/bulk-action`** →
+`BulkActionAlerts` (`dashboard_handlers.go:759`) → per-fingerprint `processAlertAction`.
+
+| Action | Path |
+|--------|------|
+| Acknowledge / Unack | `backendClient` gRPC + auto audit comment |
+| Comment add/delete | `backendClient` gRPC (`/alert/:fp/comments`) |
+| **Silence / Unsilence** | **bypass the backend** — call `alertmanagerClient` directly on **every** configured Alertmanager |
+| **Resolve** | **local-only** — flips `IsResolved`/`Status.State` in the cache + audit comment; does **not** touch Alertmanager |
+| Hide (global) | `hiddenAlertsService` via `/hidden-alerts` |
+| Hide in filter | client-only mutation of the active preset's `filterHiddenAlerts` |
+
+> ⚠️ Two mental models coexist and are easy to confuse: **collaboration** (ack/comment/resolve)
+> goes through the backend gRPC client; **silence** goes straight to Alertmanager(s).
+> **"Resolve" is cosmetic** — the alert reappears on the next Alertmanager sync if still firing
+> upstream. **"Hide in Filter" is lost on reload** unless the user re-saves the preset via
+> `updateActiveFilterPreset()`. Comment/ack counts on rows are maintained by incrementing
+> `alert.CommentCount` in the cache, not re-queried.
+
+## Alert detail modal
+
+`AlertDetailsModal` (`components/modal_components.templ:921`), opened by
+`showAlertDetails(fingerprint)` (`dashboard_modal.templ:6`), which `pushState`s the URL to
+`/dashboard/alert/:fingerprint` so deep links work (`router.go:354` re-renders the page and
+`checkAlertFromURL()` reopens the modal). Data comes from `GET /api/v1/dashboard/alert/:fingerprint`
+→ `GetAlertDetails` (`dashboard_handlers.go:1231`): the cached alert plus, if the backend is
+connected, its comments and acknowledgments.
+
+Tabs: **Overview**, **Details** (fingerprint, generator URL), **Labels** / **Annotations**
+(copy-to-clipboard), **Acknowledgments**, **Comments** (add/delete; system comments show a badge),
+**History** (lazy `GET /alert/:fp/history` → up to 50 fire/resolve/ack occurrences with MTTR/MTTA),
+and **Sentry** (only if the alert carries a `sentry` annotation/label; lazy-loaded). Header offers
+Silence/Unsilence, configurable per-user **annotation buttons**, Ack/Unack, "Source"
+(`generatorURL`), and "Copy as Issue" (builds a Markdown issue and copies it).
+
+> ⚠️ The modal's `Silences` field is **always empty** (`dashboard_handlers.go:1289`, not
+> implemented) — only `status.silencedBy` IDs are available.
+
+## Filter presets, resolved view, colors
+
+- **Filter presets** (`scripts/dashboard_filter_presets.templ`): `captureCurrentFilterState()`
+  serializes search, all filter arrays, ack/comment filters, display/view mode, group-by, sort,
+  page size, optionally column configs, and filter-scoped hides — into `FilterPresetData`. CRUD via
+  `/api/v1/dashboard/filter-presets` (gRPC-backed), with shared-vs-personal (`is_shared`) and a
+  per-user default that loads at boot.
+- **Resolved alerts view** (`displayMode==='resolved'`) is **not** from the cache — it queries the
+  statistics subsystem (`POST /api/v1/statistics/recently-resolved`) and reconciles historical
+  "resolved" against live cache status. Full detail in [statistics](statistics.md#recently-resolved).
+- **Colors**: `getAlertColor()` (`dashboard_utilities.templ:540`) returns per-row colors from
+  either rule-based **user color preferences** (server-computed, `/alert-colors`) or a hardcoded
+  severity-fallback palette. See [domain](domain.md#collaboration-state-persisted-by-the-backend).
+
+## Notification hooks
+
+The dashboard doesn't implement notifications; it calls `window.notificationService`. On first
+load it seeds the "seen" set (`initializeSeenAlerts`); on every merge it calls
+`processNewAlerts(this.alerts, this.filters, this.currentUser.id)` (`dashboard_data.templ:367`). A
+dismissible banner prompts for browser-notification permission. Full behavior in
+[notifications](notifications.md).
+
+## Gotchas {#gotchas}
+
+- **`alertMatchesFilters()` (client) must mirror `applyDashboardFilters()` (server)** — or live
+  updates go stale for the unmirrored filter. This is the #1 dashboard footgun.
+- **Dead legacy components:** `components/table_components.templ` (`AlertsTable`,
+  `SortableHeader`, `ResizableHeader`) and `column_config_tab.templ` (`ColumnConfigTab`) are
+  defined but **never referenced** — the live page uses `DynamicAlertsTable` and the standalone
+  `ColumnConfigModal`. Grep before editing.
+- **Two column-width systems:** the modern dynamic `columns[]` (server-persisted) vs. a vestigial
+  `localStorage['dashboardColumnWidths']` used only by the dead `table_components.templ`. Only
+  touch the former.
+- **Resolve is local-only; Silence bypasses the backend** (see actions above).
+- **`window.dashboardInstance`** is relied on across the codebase — don't rename/remove it.
+- Classic-mode ack/resolved counters are special-cased with a second pass
+  (`dashboard_handlers.go:681`) — account for it when changing counter logic.

--- a/openwiki/domain.md
+++ b/openwiki/domain.md
@@ -1,0 +1,99 @@
+# Domain concepts
+
+The vocabulary of Notificator. Each concept has one canonical definition here; other pages link
+to it rather than redefining.
+
+## Alert
+
+An `Alert` (`internal/models/alert.go`) mirrors an Alertmanager alert: `Labels`, `Annotations`,
+`StartsAt`, `EndsAt`, `GeneratorURL`, `Status`, and `Source` (which Alertmanager it came from).
+Convenience getters read conventional labels/annotations with safe defaults:
+
+- `GetAlertName()` ← label `alertname` (default `"Unknown"`)
+- `GetSeverity()` ← label `severity` (default `"unknown"`)
+- `GetTeam()` ← label `team` (default `"unknown"`)
+- `GetInstance()` ← label `instance`
+- `GetSummary()` ← annotation `summary`
+
+### Fingerprint (alert identity)
+
+`GetFingerprint()` is an **MD5 hash of the alert's labels sorted `key=value` and joined**. This
+is the stable identity used everywhere — as the key of the alert cache, the join key for
+comments/acks, and the `fingerprint` field in statistics. Because it is derived purely from
+labels, the same logical alert has the same fingerprint across different Alertmanagers.
+
+> The WebUI normalizes some upstream values before fingerprinting/coloring
+> (`suppressed`→`silenced`, `information`→`info`; see [webui](webui.md#alert-cache)) so
+> identity and severity stay consistent regardless of Alertmanager version.
+
+## Status: firing / silenced / inhibited / resolved
+
+`AlertStatus{State, SilencedBy, InhibitedBy}`. A **silence** (`internal/models/silence.go`,
+`Silence{Matchers, StartsAt, EndsAt, CreatedBy, Comment, Status}`) suppresses matching alerts;
+`IsSilenced()` is true when the state is `silenced` or `SilencedBy` is non-empty. An alert is
+**inhibited** when another alert suppresses it (`InhibitedBy`). **Resolved** means it stopped
+firing — at which point the WebUI archives it (see resolved alerts below).
+
+## Filtering
+
+`internal/filters/filter.go` — `AlertFilter{SearchText, Severity, Status, Team}` with
+case-insensitive substring matching over alertname/summary/team/instance. This is the simple
+server-side filter; the dashboard also has rich client-side filtering in the `.templ` scripts.
+
+## Collaboration state (persisted by the backend)
+
+These live in the backend DB and are edited over gRPC (`proto/alert.proto`, `AlertService`):
+
+- **Comment** — free-text note on an alert (by fingerprint/alert_key), authored by a user.
+- **Acknowledgment** — a user claiming/owning an alert, with an optional reason. `AlertUpdate`
+  events (comment/ack added/deleted) are broadcast to subscribers in real time.
+- **Resolved alert** — a snapshot of a resolved alert plus its comments/acks, JSON-serialized,
+  with a **TTL** (`ExpiresAt`, default 24h). Kept so the team can review recently-resolved
+  incidents; auto-purged after expiry. (Note: the newer statistics system, below, is the
+  primary historical store; this is the short-lived "recently resolved with context" view.)
+- **Hidden alert / hidden rule** — a user (or admin-impersonated user) can hide a specific alert
+  (by fingerprint) or define a **hidden rule** (label key/value, optional regex, priority) to
+  hide matching alerts from their view.
+- **Filter preset** — a saved, optionally shared/default filter configuration (JSON `filter_data`).
+- **User color preference** — rule-based alert coloring: `label_conditions` → color, with a
+  `priority` for conflict resolution and lightness/darkness factors.
+- **Annotation button config** — configurable per-user buttons that surface specific annotation
+  keys on an alert.
+- **Notification preference** & **column preferences** — per-user browser/sound notification
+  toggles and dashboard column layout.
+
+All of these accept an optional `impersonate_user_id` so an admin can manage another user's data
+(see [webui](webui.md#auth)).
+
+## Statistics & on-call analytics {#statistics}
+
+The `StatisticsService` (`proto/alert.proto`) turns alert lifecycle events into metrics. Each
+captured `AlertStatistic` records `FiredAt`, `AcknowledgedAt`, `ResolvedAt`, plus derived
+durations:
+
+- **MTTR** (Mean Time To Resolve) = `resolved − fired`
+- **MTTA** (Mean Time To Acknowledge) = `acknowledged − fired`
+- **Fix Time** = `resolved − acknowledged`
+
+`QueryStatistics` aggregates these over a time range with optional severity/team filters,
+grouped by `severity | team | alert_name | period(hour/day/week/month) | none`. Averages are
+`NULLIF(x,0)`-guarded so zero-second results don't drag the mean down.
+
+### On-call rules & time-of-day filtering
+
+An **on-call rule** (`RuleConfig{criteria, logic}` with `RuleCriterion` on severity/label/
+alert_name and operators like `equals`/`in`/`regex`) selects which alerts count as on-call load.
+Separately, **time-of-day filtering** counts an alert if its **active interval
+`[fired_at, resolved_at]` overlaps** the configured window (e.g. 18:00–08:00, cross-midnight
+supported), with `weekend_mode` = `exclude | same_hours | full_weekends`.
+
+> The overlap semantics were a bug fix (commit `4ed9ce0`): a daytime-fired alert that runs into
+> the night window **is** on-call load and must be counted. The reference implementation and its
+> intended behavior live in `internal/backend/services/statistics_query.go` and the regression
+> test `statistics_oncall_test.go`. See [backend](backend.md#statistics-engine).
+
+### Statistics views
+
+A **statistics view** (`StatisticsViewData`) is a saved, optionally shared analytics
+configuration: date range (relative or absolute), time-of-day window, grouping, filters, and
+top-N limit — the analytics-dashboard equivalent of a filter preset.

--- a/openwiki/notifications.md
+++ b/openwiki/notifications.md
@@ -1,0 +1,126 @@
+# Notification System
+
+There are **two unrelated notification systems** in the tree. Know which one you're touching.
+
+| System | Where | Status |
+|--------|-------|--------|
+| **Browser notifications** (visual + sound, in the WebUI) | `scripts/notification_service.templ` + `components/notification_settings.templ` + `handlers/notification_handlers.go` + backend gRPC + DB | **LIVE — the real system** |
+| **Desktop notifier** (Fyne OS tray + audio devices) | `internal/notifier/notifier.go`, `internal/audio/*` | **DEAD — unwired, delete-me** |
+
+This page documents the live browser system and the dead one only enough to remove it. Never edit
+`*_templ.go` — see [operations](operations.md#codegen). The live system was hardened by a
+dedicated audit (see the `fix(notifications):` history); the behavior below is the current state.
+
+## Browser notifications (supported)
+
+The client object `window.NotificationService`
+(`internal/webui/templates/scripts/notification_service.templ:6`) is injected into the dashboard
+via `@scripts.NotificationService()` and driven by the dashboard's alert lifecycle (see
+[dashboard](dashboard.md#notification-hooks)).
+
+### Permission and load ordering
+
+`init(userID)` (`notification_service.templ:20`) runs from the dashboard's `loadCurrentUser()`,
+which is now **awaited** in `dashboard_core.templ init()` before SSE and the first data load — so
+the seen-set is seeded before live updates are processed. `init` loads saved preferences, reads
+`Notification.permission` (**does not auto-prompt**), and loads the `seenAlerts` set from
+`localStorage` (`notificator_seen_alerts_<userID>`, 24h TTL). `Notification.requestPermission()`
+fires only on a user gesture: the Settings → Notifications link or the dismissible banner
+(`enableNotifications()`, `dashboard_core.templ`). The banner's dismissed state is stored under a
+**per-user** key, and its dismiss button carries an `aria-label`.
+
+### What triggers a notification
+
+Alerts flow through one choke point, `applyIncrementalUpdate(update, source)`
+([dashboard](dashboard.md#live-updates-sse-and-the-client-side-merge)), which ends by calling
+`processNewAlerts(this.alerts, this.filters, userID)` (`notification_service.templ`):
+
+1. On the initial full load, `initializeSeenAlerts()` **seeds** the seen-set. It now **merges**
+   (union) into the existing set rather than replacing it, and is seeded **once per session**
+   (gated on `seenAlertsInitialized` at the `dashboard_data.templ` call site) — so filter changes
+   and pagination no longer forget or re-notify already-seen alerts.
+2. `detectNewAlerts()` diffs live alerts against `seenAlerts`.
+3. New alerts are filtered through the user's **current dashboard filters** *and* the user's
+   **global hidden-alerts list** — globally hidden alerts are marked seen but never notified.
+4. Survivors are shown with a 500ms stagger; all newly-seen fingerprints are marked seen.
+
+`shouldNotify(alert)` gates on: browser notifications enabled, permission granted, and the alert's
+normalized severity being in `enabledSeverities`. `critical-daytime` is normalized to `critical`
+so it can notify (and gets `requireInteraction`).
+
+**Resolved / flapping alerts re-notify.** When the SSE stream reports an alert removed (a genuine
+Alertmanager resolve), `applyIncrementalUpdate` calls `forgetAlerts()` to evict it from the
+seen-set — so a later re-fire of the same fingerprint notifies again. This eviction is scoped to
+**SSE-sourced removals only** (`source === 'sse'`); the *poll* path's `removedAlerts` conflate
+resolve with filter-out and therefore never evict. See
+[dashboard](dashboard.md#live-updates-sse-and-the-client-side-merge).
+
+### What it shows
+
+`showNotificationImmediate()`: title `Alert: <name>`, body = summary (or `<SEVERITY> alert from
+<source>`), a per-severity PNG icon from `static/images/`, `tag: fingerprint` (OS-level dedup),
+and `requireInteraction: true` for `critical`/`critical-daytime`. Clicking focuses the window and
+opens the alert detail modal (or navigates to `/dashboard/alert/<fingerprint>`).
+
+### Severity, sound, and spam control
+
+- **Severity** — `enabledSeverities` defaults to `['critical', 'warning']`; `info` is off by
+  default. `information`→`info` and `critical-daytime`→`critical` are normalized for the check.
+- **Sound** — `playNotificationSound()` creates a fresh `Audio` per notification at fixed volume
+  0.7, gated by `soundNotificationsEnabled`. Files in `static/sounds/`.
+- **Spam control** — dedup via the `seenAlerts` set + 24h `localStorage` TTL (now applied on
+  **every** write in `markAsSeen`, not just at page load, so storage stays bounded); a 5/minute
+  rate limit with a retry queue; a 500ms batch stagger; OS-level `tag` dedup; and **cross-tab**
+  dedup via a per-user `BroadcastChannel` (`notificator_seen_alerts_<userID>`) that shares
+  newly-seen fingerprints so other tabs don't re-notify (feature-detected; browsers without
+  `BroadcastChannel` fall back to per-tab behavior). A **catch-up pass** runs on tab refocus so
+  alerts that fired while the tab was hidden are still evaluated.
+
+### Preferences persistence
+
+Model `NotificationPreference` (`internal/backend/models/notification_preference.go`): one row per
+user (`browser_notifications_enabled` default false, `enabled_severities` JSONB default
+`[critical, warning]`, `sound_notifications_enabled` default true). Path:
+`GET/POST /api/v1/notifications/preferences` (`handlers/notification_handlers.go`) →
+`backendClient` gRPC → `services.go` → `database/notification_db.go`.
+
+Hardened behavior:
+- **Saves send all three fields** — the client no longer omits `sound_notifications_enabled`, so
+  enabling notifications never silently disables sound.
+- The DB layer **updates explicit columns** (`Model(&existing).Select(...).Updates`) instead of a
+  full-row `Save`, so a partial payload can't wipe untouched fields.
+- Not-found is detected via `errors.Is(err, gorm.ErrRecordNotFound)`.
+- `GetNotificationPreferences` **surfaces genuine DB errors** (Success:false / HTTP 500) instead
+  of returning a fake "success + defaults" response; a true not-found still yields defaults.
+- The Settings modal uses `window.notificationService` as the **single source of truth** — it
+  copies the service's preferences only once they've actually loaded (`preferencesLoaded` guard),
+  otherwise falls back to its own fetch, avoiding the "overwrite with defaults" race.
+
+## Desktop notifier (deprecated — delete candidate)
+
+`internal/notifier/notifier.go` (~556 lines) is a **completely separate** pipeline for the removed
+Fyne desktop GUI: OS tray notifications, escalation detection, per-alert cooldown,
+`SeverityRules`, and device-aware audio via `internal/audio/*`. Its config is
+`config.NotificationConfig` / `Config.Notifications`.
+
+**Confirmed dead:** nothing constructs a `Notifier`; `internal/audio` is imported only by
+`notifier.go`; `fyne.io/fyne/v2` in `go.mod` exists **only** for `notifier.go`; the desktop
+command is gone (only the `nogui` error stub remains). See
+[architecture](architecture.md#build-variants). `internal/notifier/`, `internal/audio/`,
+`config.NotificationConfig` / `Config.Notifications`, and the `fyne` dependency can be removed
+together in one cleanup PR.
+
+## Gotchas {#gotchas}
+
+- **Two `NotificationConfig`-ish types:** the dead `notifier.NotificationConfig` vs. the live
+  DB-backed `models.NotificationPreference`. Don't confuse them when grepping.
+- **Seen-set eviction is SSE-only by design** — the poll path deliberately does not evict, because
+  its `removedAlerts` conflate resolve with filter/silence/ack/pagination. Don't add eviction
+  there without a backend signal distinguishing the two.
+- **Cross-tab dedup is best-effort** — `BroadcastChannel` only; unsupported browsers (or private
+  windows in some browsers) still notify per-tab.
+- **No shared/preloaded audio element** — a new `Audio` object is created per notification; if
+  sound "doesn't play", check the browser autoplay-policy console warning first.
+- **Minor, not yet addressed:** each rate-limited notification schedules its own queue-drain timer
+  (redundant); a rejected notification can still consume a rate slot (the guard runs after
+  `recordNotification`); and `getNotificationSound` has no `success` entry (falls back to info).

--- a/openwiki/operations.md
+++ b/openwiki/operations.md
@@ -1,0 +1,119 @@
+# Operations
+
+How to build, run, test, deploy, and maintain Notificator. All Make targets live in `Makefile`
+(`make help` lists them).
+
+## Local testing — `make test` (the primary dev loop)
+
+The maintainer's normal way to test a new feature is a full docker-compose rebuild:
+
+```bash
+make test
+```
+
+`make test` (`Makefile:209`) runs `webui-full-rebuild` + `docker-build-all`, then
+`docker-compose down && docker-compose up -d`. It rebuilds the WebUI assets (CSS + templates),
+builds all three images (backend, webui, fake-alertmanager), and restarts the stack. This is the
+recommended way to exercise changes end-to-end against a realistic environment (Postgres + fake
+Alertmanager + backend + webui). See the Compose topology below.
+
+For faster inner-loop iteration without Docker:
+
+```bash
+make run-all          # runs backend then webui via `go run`, concurrently
+# or individually:
+make dev-backend
+make dev-webui        # regenerates templates first, then `go run . webui`
+```
+
+## Build variants
+
+| Target / command | Output | Tags |
+|------------------|--------|------|
+| `make go-build-backend` | `bin/backend` | (Docker uses `-tags nogui`) |
+| `make go-build-webui` | `bin/webui` | (Docker uses `-tags "nogui,webui"`) |
+| `Dockerfile.backend` | server backend image | `-tags nogui` |
+| `Dockerfile.webui` | server webui image | `-tags "nogui,webui"` |
+
+See [architecture](architecture.md#build-variants). The `go-*-desktop` targets and the default
+tagless build are **not useful** — the desktop GUI command has been removed.
+
+## Codegen — never edit generated files {#codegen}
+
+Three generated artifact families. **Edit the source, run the target, never touch the output:**
+
+| Generated (do NOT edit) | Source | Regenerate with |
+|-------------------------|--------|-----------------|
+| `internal/webui/**/*_templ.go` | `internal/webui/templates/**/*.templ` | `make webui-templates` (`templ generate`) |
+| `internal/webui/static/css/output.css` | `internal/webui/static/css/input.css` | `make webui-css` (dev) / `make webui-css-prod` |
+| `internal/backend/proto/**/*.pb.go` | `proto/alert.proto`, `proto/auth.proto` | `make proto` (`scripts/generate_proto.sh`) |
+
+`make webui-full-rebuild` does clean + npm install + CSS build + template generate in one shot
+(this is what the WebUI Docker image runs).
+
+> LSP tip: after `make proto` your editor's Go language server may report stale "unknown field"
+> errors on the regenerated `.pb.go`. Trust `go build`, not the LSP, until it re-indexes.
+
+## Deployment
+
+### Docker Compose (`docker-compose.yml`)
+
+Four services on one bridge network:
+
+| Service | Image | Ports |
+|---------|-------|-------|
+| `postgres` | `postgres:15-alpine` | 5432 |
+| `alertmanager` | `soulkyu/notificator-alertmanager` (fake) | 9093 |
+| `backend` | `soulkyu/notificator-backend` | 50051 (gRPC), 8080 (HTTP) |
+| `webui` | `soulkyu/notificator-webui` | 8081 |
+
+Dependency order is enforced by healthchecks (backend waits for postgres+alertmanager; webui
+waits for backend). All config is passed as inline env vars (OAuth and Sentry disabled by
+default). Set `NOTIFICATOR_SESSION_SECRET` in your host env for session persistence across
+restarts — it defaults empty.
+
+### Kubernetes (`charts/notificator-app/`)
+
+Helm chart (chart `v0.1.0`). Renders backend + webui **Deployments** (1 replica each, no HPA),
+Services, ServiceAccounts, and a webui **Ingress** (nginx class, optional TLS). The in-cluster
+Alertmanager deployment is off by default (`alertmanager.enabled: false`) — you point at an
+external Alertmanager via the top-level `alertmanagerConfig` list.
+
+```bash
+helm install notificator oci://ghcr.io/soulkyu/notificator --version 0.1.0 \
+  --set webui.ingress.host=notificator.example.com
+```
+
+`values.yaml` exposes per-service `image`, `labels`/`annotations`, `securityContext`
+(**empty/unhardened by default** — set `runAsNonRoot`, drop capabilities, etc. for production),
+`serviceAccount`, and free-form `env: {}` maps to inject any `NOTIFICATOR_*` / `OAUTH_*` var.
+
+> ⚠️ **Single backend replica only.** Real-time collaboration subscriptions are in-process
+> (see [backend](backend.md#real-time-collaboration-push)) — do not scale the backend `Deployment`
+> above 1 replica without adding an external pub/sub.
+
+## Health & metrics
+
+The backend serves `GET /health` and `GET /metrics` on `:8080`. **`/metrics` is JSON, not
+Prometheus exposition format** — don't point a Prometheus scraper at it expecting text metrics.
+The WebUI serves `/health` on `:8081`. Compose/Helm use these for readiness.
+
+## Database maintenance
+
+- **Migrations** run automatically on backend start (`--migrate`, default on). Custom migrations
+  run before GORM `AutoMigrate` (see [backend](backend.md#database)).
+- **Retention** is automatic: resolved-alert rows expire by TTL (hourly cleanup); statistics rows
+  are purged after `Statistics.RetentionDays` (daily, default 90d).
+- **SQLite vs Postgres**: SQLite is fine for local/dev (default `./notificator.db`); use Postgres
+  for production. CGO must be enabled to build with SQLite (both Docker images do this). Note the
+  statistics **heatmap and flapping** queries are **PostgreSQL-only** (see
+  [backend](backend.md#statistics-engine)) — they error on SQLite.
+- **Timezones**: the binary blank-imports `time/tzdata` (`main.go`), so IANA zones resolve even in
+  alpine-based images that ship no `/usr/share/zoneinfo` — required for timezone-aware statistics
+  period/heatmap bucketing.
+
+## Fake Alertmanager (`alertmanager/fake/`)
+
+A Python (uv/pyproject) mock implementing Alertmanager's `/api/v2/*` surface, so you can run and
+test the whole stack without a real Prometheus/Alertmanager. It ships its own `Dockerfile` and is
+the `alertmanager` service in Compose.

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -1,0 +1,97 @@
+# Notificator — Quickstart
+
+Notificator is a **team-oriented web UI for Prometheus Alertmanager**. It connects to
+one or more Alertmanagers (including multi-tenant Grafana Mimir / Cortex) and shows every
+firing alert in a single dashboard, with real-time collaboration: acknowledgements,
+comments, assignments, hidden alerts, and historical statistics (MTTR / MTTA / on-call
+analytics).
+
+The project is a Go monorepo. The supported runtime is **two cooperating processes**:
+
+- **Backend** (`notificator backend`) — a gRPC + HTTP server that owns the database, auth,
+  sessions, OAuth, alert-collaboration state, and the statistics engine.
+- **WebUI** (`notificator webui`) — a Gin web server that renders the browser UI, polls
+  Alertmanager for live alerts, and calls the backend over gRPC for everything persistent.
+
+> ⚠️ **Deprecated: the Fyne desktop GUI.** The project once shipped a third variant — a Fyne
+> desktop app (`notificator desktop`). It is **unmaintained and its command has already been
+> removed** from this checkout: a plain `go build .` produces a binary with only the `backend`
+> command (a `desktop` stub appears only under `-tags nogui`, and it just prints an error).
+> What remains is dead cruft — the `internal/notifier` and `internal/audio` packages (both
+> import Fyne but are wired to nothing), the `gui` / `notifications` config sections,
+> `FyneApp.toml`, the `fyne.io/fyne/v2` dependency in `go.mod`, and the `go-*-desktop` Makefile
+> targets. These should be deleted. See [architecture](architecture.md#build-variants).
+
+## Run it locally
+
+```bash
+# Server build (excludes the desktop GUI)
+go build -tags "nogui,webui" -o notificator .
+
+./notificator backend    # gRPC :50051, HTTP :8080 (health/metrics)
+./notificator webui      # http://localhost:8081
+```
+
+Log in at `http://localhost:8081` with `admin:admin` (change it). The WebUI defaults to an
+Alertmanager at `localhost:9093`; point it at yours via config or env
+(see [configuration](configuration.md)).
+
+Docker Compose brings up the whole stack (Postgres + fake Alertmanager + backend + webui):
+
+```bash
+docker-compose up -d      # WebUI at http://localhost:8081
+```
+
+See [operations](operations.md) for Compose, Helm, and build/codegen details.
+
+## Architecture at a glance
+
+```
+Browser ──HTTP/SSE──► WebUI (:8081) ──gRPC──► Backend (:50051) ──► DB (SQLite / Postgres)
+                        │                         ▲
+                        └──HTTP poll──► Alertmanager(s) :9093
+```
+
+Live alerts flow **WebUI ← Alertmanager** (polling, fanned out to browsers via SSE). Everything
+persistent (users, comments, acks, resolved-alert history, statistics, preferences) flows
+**WebUI → Backend → DB** over gRPC. The two real-time mechanisms are distinct — see
+[architecture](architecture.md#real-time).
+
+## Repository map
+
+| Path | What lives there |
+|------|------------------|
+| `main.go`, `cmd/` | Cobra entrypoints: `backend`, `webui`, `desktop` (stub in server builds) |
+| `config/` | Config structs + Viper loading (JSON + env + flags); OAuth config |
+| `proto/` | `alert.proto` (AlertService + StatisticsService), `auth.proto` (AuthService) |
+| `internal/backend/` | gRPC server, services, GORM database, domain models |
+| `internal/webui/` | Gin router, middleware, handlers, gRPC client, `templ` templates, alert cache |
+| `internal/alertmanager/` | Multi-Alertmanager HTTP client (multi-tenant headers) |
+| `internal/models/` | Core `Alert` domain model + fingerprinting |
+| `internal/{notifier,audio}/` | ⚠️ desktop-only (Fyne) — deprecated |
+| `charts/notificator-app/` | Helm chart (backend, webui, alertmanager, ingress) |
+| `alertmanager/fake/` | Python fake Alertmanager for local dev/testing |
+| `docs/` | OAuth setup guides, design/implementation plans, Alertmanager OpenAPI |
+
+## Where to go next
+
+- [Architecture](architecture.md) — components, ports, request flow, real-time, build variants
+- [Backend](backend.md) — gRPC services, auth/sessions, database, statistics engine
+- [WebUI](webui.md) — routing, templ/HTMX/Alpine, SSE, auth, dashboards
+- [Live dashboard](dashboard.md) — the alert table: SSE merge, filters, actions, columns, modal
+- [Statistics dashboard](statistics.md) — analytics: time ranges, on-call filtering, charts, saved views
+- [Notification system](notifications.md) — browser notifications + sound (and the dead desktop notifier)
+- [Domain concepts](domain.md) — alerts, fingerprints, acks/comments, resolved alerts, on-call rules
+- [Configuration](configuration.md) — config layering, env vars, multi-tenant, OAuth, Sentry
+- [Operations](operations.md) — deploy, build, codegen, database retention, health
+
+## For future agents — where to be careful
+
+- **Never edit `*_templ.go` or `*.pb.go`** — they are generated. Edit the `.templ` / `.proto`
+  source and regenerate (`make webui-templates`, `make proto`). Same for `output.css`
+  (`make webui-css`). See [operations](operations.md#codegen).
+- The backend has **no auth interceptor** — every gRPC handler validates `session_id` by hand.
+  A new RPC that forgets the check is wide open. See [backend](backend.md#auth).
+- Several "admin only" endpoints are **not actually enforced**; some code paths are dead or
+  broken (`profile` timezone update panics). Known-issue list in [backend](backend.md#gotchas)
+  and [webui](webui.md#gotchas).

--- a/openwiki/statistics.md
+++ b/openwiki/statistics.md
@@ -1,0 +1,190 @@
+# Statistics Dashboard
+
+The statistics dashboard (`/statistics`) is the app's analytics surface: aggregate alert metrics
+(counts, MTTR / MTTA / fix-time) over a time range, with grouping, on-call time-of-day filtering,
+charts, drill-down, and saved views. This page covers the UI and what it sends/displays; the
+backend query engine (capture, storage, the on-call overlap SQL) is documented in
+[backend](backend.md#statistics-engine), and the metric definitions in
+[domain](domain.md#statistics).
+
+**Source:** page `internal/webui/templates/pages/StatisticsDashboard.templ` (component
+`statisticsDashboardPage()`); saved-views mixin
+`internal/webui/templates/scripts/statistics_views.templ`; handlers
+`internal/webui/handlers/statistics_handlers.go` and `statistics_view_handlers.go`. Never edit
+`*_templ.go` — see [operations](operations.md#codegen).
+
+## Client architecture and bootstrap
+
+The page scope spreads two independently-defined mixins onto one Alpine object
+(`StatisticsDashboard.templ:43`): `statisticsDashboardPage()` (state + query/chart logic) and
+`statisticsViewsMixin()` (saved views + timezone helpers). Boot order: Alpine calls the mixin's
+`init()` → `initPage()` (sets the on-call time preset, watches) → registers `$watch` on every
+filter so any edit sets **`needsQuery = true`** (pulsing the Query button) and clears the active
+view → `initViews()` loads saved views, applies the user's default if any, then **always** fires
+one `queryStatistics()` on first paint.
+
+Default filters: `groupBy: 'team'`, `periodType: 'day'`, `limit: 20`,
+`severities: ['critical','critical-daytime']`, relative range "last 7 days → now", time-of-day
+overridden to the on-call schedule.
+
+> Charts use **Chart.js 4.4.1 + the date-fns adapter, loaded per-page from a CDN**
+> (`StatisticsDashboard.templ:19`) — separate from the app-wide Alpine/htmx/Day.js bundle in
+> `layouts/Base.templ`. A CDN outage degrades only chart rendering on this page.
+
+## Time range selection
+
+Two modes (`filters.timeRangeMode`), plus quick presets (1h/24h/7d/30d/90d):
+
+- **Relative** — numeric value + unit (minutes…years) for "From" and "Until", with "All Time" /
+  "Now" toggles. Backed by `RelativeTimeConfig` (`value`, `unit`, `all_time`, `now`;
+  `proto/alert.proto:1073`). Values are clamped per unit (max 365 days, 10 years).
+- **Absolute** — `<input type=date>` + `<input type=time>` pairs.
+
+Both modes compute `filters.startDate` / `endDate` as plain `YYYY-MM-DD` strings.
+
+In **relative** mode the wire dates are day-boundary (`T00:00:00Z` / `T23:59:59Z`). In **absolute**
+mode the custom `absoluteFromTime` / `absoluteUntilTime` **are now honored** — the start/end
+timestamps reflect the chosen time-of-day rather than being forced to day boundaries. Relative
+ranges also support a `years` granularity. Queries carry an explicit `timezone` (field 18), so
+period/heatmap bucketing happens in the user's zone (the binary embeds `time/tzdata`, so IANA
+zones resolve even in alpine containers — see [operations](operations.md)).
+
+## Time-of-day / on-call filtering
+
+UI (`StatisticsDashboard.templ:321`): lenient `HH:MM` inputs (accepts `0900`/`9`/`902`), a
+24-segment visual timeline (correct overnight wrap), six preset chips (On-Call / Morning / Noon /
+Business / Evening / Night), and a **weekend-mode** select (`exclude` / `same_hours` /
+`full_weekends`). The On-Call preset reads the user's on-call schedule from
+`localStorage.dashboardSettings.onCallSchedule` (default 18:00→08:00, weekends included) and locks
+weekend-mode to `full_weekends`.
+
+`isTimeFilterActive()` computes the `filter_by_time_of_day` flag: true unless the window is the
+full day *and* weekend-mode is `same_hours`. Every query payload
+(`queryStatistics`, the four chart loaders, the drill-down) sends the same five fields:
+`filter_by_time_of_day`, `time_of_day_start`, `time_of_day_end`, `weekend_mode`, plus
+`severities` / `teams`. See [domain](domain.md#on-call-rules--time-of-day-filtering) and the
+regression-sensitive overlap semantics in [backend](backend.md#on-call-overlap-filter-regression-sensitive).
+
+> ⚠️ **Time-of-day UTC asymmetry.** The live query sends raw `HH:MM`. The *saved-view* path
+> converts to UTC on **save** (`convertTimeToUTC`) but does **not** convert back on **apply** —
+> so reloading a saved view in a different timezone can shift the effective on-call window. There
+> is no `use_on_call_period` boolean on the wire despite the proto field existing; on-call is
+> implemented purely as a time-of-day preset.
+
+## Grouping
+
+`groupBy`: Overall (`''`) / `severity` / `team` / `alert_name` / `period`. When `period`, a
+`periodType` (hour/day/week/month) appears; when `alert_name`, a Top-N input (`limit`, default 20).
+`secondary_group_by` is **not** user-facing — it's set internally to break the time-series chart
+into series within each bucket. Overall/severity/team/alert_name render the sortable **"Statistics
+by Group"** table plus the four charts; `period` renders a **"Period Breakdown"** card list instead
+(the resolution-times chart is hidden for period grouping). `group_by`/`period_type`/`weekend_mode`
+are plain strings in the proto (not enums) — typos yield empty results, not errors.
+
+## Metrics and charts
+
+Metrics come from `AggregatedStatistics` (`count`, `avg_mttr_seconds`, `avg_mtta_seconds`,
+`avg_fix_time_seconds`). Formatters: `formatDuration` ("1h 5m 3s"), `formatMTTR`/`formatTimeOrNA`
+(render `N/A` for a `0` value, not "0s"), `formatNumber` (K/M). The overall KPI tiles are
+**alert-count-weighted** (`sum(total_seconds)/sum(count)`, using `total_*_seconds` from the backend
+when present) rather than an average-of-averages. Four Chart.js instances:
+
+| Chart | Type | Purpose |
+|-------|------|---------|
+| Alerts Over Time | line | fired/resolved/both, or per-group series with a dashed "Total" |
+| Distribution | doughnut | Top-10 + "Others", with a Chart/List toggle |
+| Top 10 Items | horizontal bar | click a bar → drill-down (when grouped by alert_name) |
+| Resolution Times | grouped horizontal bar | MTTR / MTTA / Fix Time per group |
+
+Each chart has a fullscreen variant. `buildKeyColorMap()` assigns one stable color per group key
+across all charts. Continuous time axes are zero-filled for missing buckets
+(`fillMissingPeriods`). A **comparison mode** queries the immediately-preceding equal-length
+period and shows % deltas (with inverted coloring so "down is good" for durations).
+
+A fifth visualization, the **Alert Noise Heatmap** (`StatisticsDashboard.templ` ~1441), is a
+custom 7×24 (day-of-week × hour) grid — not Chart.js — colored by a Volume/MTTR toggle
+(`heatmapMetric`). It loads via `loadHeatmap()` → `POST /api/v1/statistics/heatmap`
+(`QueryHeatmap`), which is **PostgreSQL-only** (uses `EXTRACT(DOW …)` / `AT TIME ZONE`) — see
+[backend](backend.md#statistics-engine).
+
+> There is also a `QueryFlappingAlerts` RPC (`POST /api/v1/statistics/flapping`), but the
+> "Top Flapping Alerts" UI section that used it was **added then removed** — the backend RPC/endpoint
+> still exist and work, they're just **unused by any current UI**.
+
+**Export is 100% client-side CSV** from the already-loaded `statsData` — there is no backend
+export endpoint.
+
+## Sharing & URL state
+
+The page serializes its full filter state into the URL after every query (`syncFiltersToURL` →
+`history.replaceState('/statistics?…')`, covering dates, grouping, period, limit,
+`includeSilenced`, time-of-day, weekend mode, time-range mode, severities/teams). A **Share**
+button copies `window.location.href`; on load, `hydrateFiltersFromURL()` restores any present
+params, and the default-saved-view auto-apply **skips itself when URL params exist** so a shared
+link isn't clobbered by the user's default view. Every statistics query is also `include_silenced`-
+and `timezone`-aware on the wire (`QueryStatisticsRequest` fields 17/18), backed by the
+`silenced_at_fire` capture column.
+
+## Severity & team filters
+
+Two searchable multi-select dropdowns. Option lists are **derived, not authoritative**:
+`loadAvailableSeverities()` / `loadAvailableTeams()` each issue their own statistics query grouped
+by severity/team over a hardcoded **trailing 90-day window** and take the option list from the
+result keys — so a severity/team appearing only in older data won't show up as an option. These
+filters (`severities` / `teams`, `repeated string`) are sent on every statistics RPC.
+
+## Drill-down
+
+- **By alert name** — `openAlertDetailsModal(alertName)` → `POST /api/v1/statistics/alerts-by-name`
+  (`GetAlertsByName`, `statistics_handlers.go:152`): a table of individual occurrences (severity,
+  fired/resolved, MTTR/MTTA/fix-time, labels). Rows are themselves clickable.
+- **Individual alert / history** — `openIndividualAlertDetails()` →
+  `GET /api/v1/statistics/alert/:fingerprint` (`GetResolvedAlertDetails`,
+  `statistics_handlers.go:372`): rendered by the shared `AlertModalReadonly` (also used by the
+  dashboard's resolved view). The backend enriches it with comments/acks and reconstructs
+  labels/annotations/source from the latest history record. The Comments tab is **no longer
+  read-only** — it uses `AlertModalCommentsWritable` (`alert_modal_shared.templ`) with an add-comment
+  box that POSTs to the dashboard's `/api/v1/dashboard/alert/:fingerprint/comments` endpoint (even
+  though the modal lives on the Statistics page).
+
+## Recently resolved {#recently-resolved}
+
+> **Not on this page.** Despite hitting the same endpoint, "Recently Resolved" is a **tab of the
+> live dashboard** (`displayMode==='resolved'`), implemented in
+> `internal/webui/templates/scripts/dashboard_resolved_alerts.templ` and mixed into
+> `NewDashboard.templ`. Don't look for it in `StatisticsDashboard.templ`.
+
+It POSTs to `POST /api/v1/statistics/recently-resolved` (`QueryRecentlyResolved`,
+`statistics_handlers.go:297`) with its own time range and only the
+`severities`/`teams`/`alertNames`/`search` filters (not alertmanager/status/ack/comment filters).
+It **always** requests `include_silenced: true`, then re-queries live cache status per fingerprint
+to reconcile "historically resolved" against "currently firing/silenced" client-side. Returns
+`ResolvedAlertItem` rows (occurrence_count, first_fired/last_resolved, avg MTTR/MTTA/fix-time,
+labels, team). Limit default 100, cap 1000, offset paging.
+
+## Saved statistics views
+
+A saved view persists the entire analytics config (`StatisticsViewData`): time-range mode +
+relative config, dates, time-of-day window (UTC-converted on save), grouping, period type,
+severities/teams, limit. CRUD via `/api/v1/statistics/views` (create/update/delete/set-default),
+shared-vs-personal (`is_shared`), with a per-user default applied at boot.
+
+**Every saved-view handler is impersonation-aware** (`middleware.GetImpersonatedUserID`), so an
+admin impersonating a user manages that user's views. (Impersonation exists only for saved views,
+not for the query/drill-down endpoints.)
+
+## Gotchas {#gotchas}
+
+- **Heatmap & flapping are PostgreSQL-only** — `QueryHeatmap`/`QueryFlappingAlerts` use PG-specific
+  SQL and error on SQLite. The flapping RPC has **no UI** (the section was removed).
+- **Time-of-day UTC asymmetry in saved views** — converted on save, not on apply.
+- **Weekend-mode does not round-trip through saved views.** `getCurrentViewData()`/`applyView()`
+  read/write dead `filters.includeWeekends`/`applyRules`/`filterByTimeOfDay` properties that don't
+  exist on `statisticsDashboardPage()`'s `filters` (which uses the 3-way `weekendMode` string
+  instead) — leftover from a pre-`weekendMode` schema. A saved view won't restore weekend-mode.
+- **Filter option lists are derived from a trailing 90-day query**, not authoritative.
+- **Export and "Recently Resolved endpoint" have no dedicated backend surface** you'd expect —
+  export is client-side; recently-resolved lives on the other page.
+- `onFilterChange()` is bound to the severity/team checkboxes but its definition wasn't located —
+  it may be a no-op/dead hook (the `$watch`ers already handle the side effects). Confirm before
+  relying on it.

--- a/openwiki/webui.md
+++ b/openwiki/webui.md
@@ -1,0 +1,112 @@
+# WebUI
+
+The WebUI (`notificator webui`, `internal/webui/`) is a server-rendered web app:
+**Gin** for HTTP, the **`templ`** templating library for HTML, **HTMX** + **Alpine.js** for
+interactivity, **Tailwind** for styling. No JS build pipeline beyond Tailwind — client-side
+logic is hand-written JS embedded inside `.templ` files. The WebUI is a **gRPC client** of the
+backend and an **HTTP client** of Alertmanager.
+
+## Startup and wiring
+
+`SetupRouter(backendAddress)` (`internal/webui/router.go:21`) loads config, builds the
+Alertmanager `MultiClient`, dials the backend gRPC client (**mandatory** — `log.Fatalf` if the
+dial target is malformed), fetches OAuth config from the backend, and wires everything into
+handlers via **package-level singleton setters** (`handlers.SetBackendClient`,
+`SetAlertCache`, `SetColorService`, …). This global-singleton pattern (not per-request DI) is
+fine for a single-instance server but blocks parallel/multi-tenant handler testing.
+
+Middleware order (`router.go:130-134`): `CORSMiddleware` → `LoggingMiddleware` →
+`gin.Recovery` → `SessionMiddleware`.
+
+## Sessions, auth, OAuth, impersonation {#auth}
+
+- **Session store:** `gin-contrib/sessions` cookie store, secret from
+  `NOTIFICATOR_SESSION_SECRET` or a **per-process random fallback** — the fallback means
+  sessions don't survive a restart (logged as a warning). Cookie `notificator-session`,
+  7-day, `HttpOnly: true`, **`Secure: false` hardcoded** (`middleware/session.go`) — must be
+  fixed for HTTPS-only production.
+- The cookie holds only an opaque `session_id` (+ cached user fields); validity is always
+  re-checked against the backend via `ValidateSession` **on every request** — no local TTL
+  cache, so backend load scales 1:1 with UI traffic.
+- **Classic login/register** (`handlers/handlers.go`) POST form creds to the backend; can be
+  disabled via OAuth `DisableClassicAuth`.
+- **OAuth** (`handlers/oauth_handlers.go`): CSRF `state` stored in session, provider auth URL
+  fetched from backend, `OAuthCallback` validates `state` before the backend exchanges the code.
+  See [configuration](configuration.md#oauth).
+- **Impersonation** (`handlers/impersonation_handlers.go`, `middleware/session.go`): admin-listed
+  users (`config.Admin.ImpersonationAllowedUsers`) can "view as" another user. Implemented as
+  extra session keys; `GetEffectiveUserID` resolves *whose data* to load, while
+  `GetEffectiveSessionID` deliberately keeps the **admin's** session for backend auth — backend
+  RPCs then carry an explicit `impersonate_user_id` to act on the target user's data server-side.
+
+## The backend gRPC client
+
+`internal/webui/client/backend_client.go` wraps every backend RPC the UI needs (auth, comments,
+acks, resolved alerts, statistics, color/column/hidden/filter preferences, OAuth, Sentry config).
+Handlers call these methods and re-marshal proto replies into `internal/webui/models` structs.
+
+## Alert cache + SSE (live alerts) {#alert-cache}
+
+`internal/webui/services/alert_cache.go` (~900 lines) is the source of truth for **live firing
+alerts** and the SSE hub:
+
+- Polls Alertmanager every `Polling.SyncInterval` (default ~10s) via the `MultiClient`, diffs
+  the in-memory `map[fingerprint]*DashboardAlert`, and normalizes upstream quirks
+  (`suppressed`→`silenced`, `information`→`info`).
+- Tracks `UpdatedAt` only on *meaningful* change (`hasAlertChanged`) to avoid UI churn — this is
+  what `alert_cache_test.go` primarily verifies.
+- Maintains a **per-user color cache** (rule-based alert coloring) refreshed after each poll.
+- On resolve, asynchronously archives the alert (with comments/acks) to the backend and fires
+  `CaptureAlertFired`/`UpdateAlertResolved` statistics events.
+- **SSE fan-out:** `Subscribe`/`Unsubscribe`/`notifySubscribers` push buffered (10),
+  **non-blocking** updates. `handlers/sse_handler.go` (`GET /api/v1/dashboard/stream`) sets
+  `text/event-stream` (+ `X-Accel-Buffering: no` for nginx), streams `update` events and 30s
+  `ping` heartbeats until the client disconnects.
+
+This is separate from the backend's gRPC collaboration stream — see
+[architecture](architecture.md#real-time).
+
+## Handlers (by feature)
+
+`internal/webui/handlers/`: `dashboard_handlers` (live dashboard + bulk actions),
+`statistics_handlers` + `statistics_view_handlers` (analytics + saved views),
+`oauth_handlers`, `profile_handlers`, `notification_handlers`, `hidden_alerts_handlers`,
+`filter_preset_handlers`, `impersonation_handlers`, `sentry_handlers`, `sse_handler`,
+`connected_users_handlers`.
+
+## Templates and the two dashboards
+
+`internal/webui/templates/` structure:
+
+- `layouts/Base.templ` — shared HTML shell; loads `output.css`, HTMX, Alpine (+ collapse),
+  Day.js from CDN; contains inline dark-mode, impersonation-banner, and connected-users JS.
+- `pages/` — `NewDashboard` (the **live operational dashboard**, `/dashboard` — deep-dived in
+  [dashboard](dashboard.md)), `StatisticsDashboard` (the **historical analytics dashboard**,
+  `/statistics` — deep-dived in [statistics](statistics.md)), `Login`, `Register`, `Profile`,
+  `OAuthCallback`, `Index`, `Playground` (dev/demo landing when `WebUI.Playground` is on).
+  Browser/sound alerts are covered in [notifications](notifications.md).
+- `components/` — tables, modals, filter/group views, timezone selector, page navigator, etc.
+- `scripts/` — **`.templ` files whose entire body is a `<script>` of hand-written Alpine.js**
+  (e.g. `dashboard_core.templ` defines `function newDashboard(){…}`). Included into pages via
+  `@scripts.DashboardCore()`. Editing client behavior means editing these `.templ` files, not
+  files under `static/`.
+
+### templ workflow {#templ}
+
+Each `.templ` compiles to a sibling `*_templ.go`. **Never edit the generated `*_templ.go`.**
+Edit the `.templ`, then run `make webui-templates` (`templ generate`). Tailwind output is
+`static/css/output.css`, regenerated with `make webui-css` — never hand-edit it either. See
+[operations](operations.md#codegen).
+
+## Gotchas {#gotchas}
+
+- **`profile_handlers.go` `UpdateTimezone`** calls `c.MustGet("db").(*gorm.DB)`, but no
+  middleware ever sets `"db"` on the gin context — the route (`PUT /profile/timezone`) will
+  **panic** (surfaced as a 500). Leftover direct-DB code in an otherwise all-gRPC UI.
+- **`middleware/session.go` `Secure: false`** is hardcoded — patch for HTTPS.
+- **`middleware/cors.go`** sets `AllowOrigins: ["*"]` with `AllowCredentials: true`, which the
+  Fetch spec disallows together — verify real browser behavior before relying on cross-origin
+  cookies.
+- **No local session cache** — every request hits the backend `ValidateSession`; add a
+  short-TTL cache here if it becomes a bottleneck.
+- **Package-level handler globals** block parallel/multi-instance handler wiring without a refactor.


### PR DESCRIPTION
## Summary

Adds the `openwiki/` documentation set plus a top-level `AGENTS.md` pointer. Generated via the OpenWiki workflow and refreshed against the current `main`, so it reflects the merged notification-system fixes (PR #31) **and** the upstream statistics/dashboard work.

**Pages:** `quickstart`, `architecture`, `backend`, `webui`, `dashboard`, `statistics`, `notifications`, `domain`, `configuration`, `operations`.

Highlights the docs capture:
- **Notifications** — current (fixed) behavior: sound persists on save, seen-set TTL + merge-once, SSE-scoped resolve re-fire, hidden-alert suppression, cross-tab dedupe, single-source preferences, backend surfaces real errors. The dead Fyne desktop notifier is flagged for removal.
- **Statistics** — alert-noise heatmap (PostgreSQL-only), shareable URL deep-links, count-weighted KPIs, honored absolute times, writable comments in the resolved-alert modal; the flapping RPC exists but has no UI.
- **Backend** — `QueryHeatmap`/`QueryFlappingAlerts` (PG-only), MTTA now written to the correct column on acknowledge, `time/tzdata` embed for alpine containers.
- **Dashboard** — ack/comments UI filters removed (backend params dormant), alert colors embedded in the data response, `applyIncrementalUpdate(update, source)`.

`AGENTS.md` points agents to `openwiki/quickstart.md` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)