### PR TITLE
chore(devtools): add factory TUI — live terminal view of the agent loop

### DIFF
--- a/devtools/factory-tui/README.md
+++ b/devtools/factory-tui/README.md
@@ -38,6 +38,7 @@ python3 devtools/factory-tui/factory-tui.py --check  # alignment self-check, exi
 | `systemctl --user` (services + timers `notificator-*`) | custom agents: scout, roast, qa, rebaser, promoter, groomer, doc, reporter — running / next wake-up / failure | 3–10 s |
 | `gh pr list` / `gh issue list` | the team board | 45 s |
 | newest file in the agents log dir | the 📻 chatter ticker | 10 s |
+| agent inboxes (`inbox/<agent>/`, `inbox/archive/`) | 📬 pending-mail badge on desks + the 💬 INTERCOM panel (last agent-to-agent messages) | 10 s |
 
 ## Configuration (env)
 
@@ -45,6 +46,7 @@ python3 devtools/factory-tui/factory-tui.py --check  # alignment self-check, exi
 |---|---|---|
 | `FACTORY_REPO` | `SoulKyu/notificator` | GitHub repo for the board |
 | `FACTORY_LOG_DIR` | `~/.claude-agents/notificator/logs` | agent logs to feed the ticker |
+| `FACTORY_INBOX_DIR` | `~/.claude-agents/notificator/inbox` | agent mailboxes for 📬 badges + 💬 INTERCOM |
 
 ## Requirements
 

--- a/devtools/factory-tui/README.md
+++ b/devtools/factory-tui/README.md
@@ -1,0 +1,59 @@
+# 🏭 Factory TUI — live view of the autonomous dev loop
+
+> **⚠️ Development tooling — NOT part of the notificator product.**
+> Everything under `devtools/` supports the development *process* of this repo
+> (the autonomous agent loop), never ships to users, and has no impact on builds
+> or releases.
+
+A zero-dependency terminal dashboard (Python stdlib `curses`) showing the agent
+"office" in real time, top-down 2D style: who is working, who is on a coffee
+break, who is asleep until their next timer, and what is on the team board
+(open PRs, issue counts, live log chatter).
+
+```
+┌─ NOTIFICATOR DEV FACTORY ──────────────────────── 14:32:07 ─┐
+│ ┌──────────┐ ┌──────────┐ ┌──────────┐                      │
+│ │🔍 SCOUT  │ │🔥 ROAST  │ │🧭 COORD  │        ...           │
+│ │⌨ tak··   │ │zZ dort   │ │☕~ pause │                      │
+│ └──audit───┘ └──15min───┘ └─poll 30s─┘                      │
+│ ── TABLEAU ────────────────────────────────────────────────  │
+│ PR#43 👀review  PR#44 🧪qa                                   │
+│ 📻 [rebase-43] go build ./... passes                         │
+└──────────────────────────────────────────────────────────────┘
+```
+
+## Run
+
+```bash
+python3 devtools/factory-tui/factory-tui.py          # live TUI (q to quit)
+python3 devtools/factory-tui/factory-tui.py --once   # one frame to stdout (tests/CI)
+```
+
+## Data sources (all read-only, polled)
+
+| Source | What it feeds | Interval |
+|---|---|---|
+| `looper ps` | looper roles: coordinator, planner, reviewer, fixer, worker | 3 s |
+| `systemctl --user` (services + timers `notificator-*`) | custom agents: scout, roast, qa, rebaser, promoter, groomer, doc, reporter — running / next wake-up / failure | 3–10 s |
+| `gh pr list` / `gh issue list` | the team board | 45 s |
+| newest file in the agents log dir | the 📻 chatter ticker | 10 s |
+
+## Configuration (env)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `FACTORY_REPO` | `SoulKyu/notificator` | GitHub repo for the board |
+| `FACTORY_LOG_DIR` | `~/.claude-agents/notificator/logs` | agent logs to feed the ticker |
+
+## Requirements
+
+- Python ≥ 3.8 (stdlib only), a UTF-8 terminal
+- `looper`, `gh` (authenticated) and the systemd user timers of the agent loop —
+  missing sources degrade gracefully (desks show "?" instead of crashing)
+
+## For agents improving this file
+
+Keep it **stdlib-only** and **read-only** (this dashboard must never mutate GitHub,
+looper state, or files outside its own process). Preserve the `--once` mode — it is
+the testable path (`python3 factory-tui.py --once` must always print a frame and
+exit 0). Emoji are double-width: any new cell rendering must go through `dpad()`.

--- a/devtools/factory-tui/README.md
+++ b/devtools/factory-tui/README.md
@@ -27,6 +27,7 @@ break, who is asleep until their next timer, and what is on the team board
 ```bash
 python3 devtools/factory-tui/factory-tui.py          # live TUI (q to quit)
 python3 devtools/factory-tui/factory-tui.py --once   # one frame to stdout (tests/CI)
+python3 devtools/factory-tui/factory-tui.py --check  # alignment self-check, exit 0/1
 ```
 
 ## Data sources (all read-only, polled)
@@ -56,4 +57,6 @@ python3 devtools/factory-tui/factory-tui.py --once   # one frame to stdout (test
 Keep it **stdlib-only** and **read-only** (this dashboard must never mutate GitHub,
 looper state, or files outside its own process). Preserve the `--once` mode — it is
 the testable path (`python3 factory-tui.py --once` must always print a frame and
-exit 0). Emoji are double-width: any new cell rendering must go through `dpad()`.
+exit 0). Emoji are double-width: any new cell rendering must go through `dpad()`,
+and `--check` must stay green — it asserts the alignment invariants (11-col monitor
+segment in every state, all frame rows at identical display width).

--- a/devtools/factory-tui/factory-tui.py
+++ b/devtools/factory-tui/factory-tui.py
@@ -22,6 +22,7 @@ import time
 import unicodedata
 
 LOG_DIR = os.environ.get("FACTORY_LOG_DIR", os.path.expanduser("~/.claude-agents/notificator/logs"))
+INBOX_DIR = os.environ.get("FACTORY_INBOX_DIR", os.path.expanduser("~/.claude-agents/notificator/inbox"))
 REPO = os.environ.get("FACTORY_REPO", "SoulKyu/notificator")
 POLL_FAST, POLL_MED, POLL_SLOW = 3, 10, 45
 
@@ -48,7 +49,8 @@ TIMER_OF = {
     "docagent": "notificator-docagent.timer", "reporter": "notificator-reporter.timer",
 }
 
-STATE = {"loops": [], "svc": {}, "timers": {}, "prs": [], "issues": "", "ticker": "", "err": ""}
+STATE = {"loops": [], "svc": {}, "timers": {}, "prs": [], "issues": "", "ticker": "", "err": "",
+         "mail_pending": {}, "intercom": []}
 LOCK = threading.Lock()
 
 
@@ -120,8 +122,27 @@ def poll_med():
                 STATE["ticker"] = f"[{name}] {line.strip()[:200]}"
     except Exception:
         pass
+    # agent-to-agent mail: pending inboxes + recent archived conversations
+    pending, intercom = {}, []
+    try:
+        for box in os.listdir(INBOX_DIR):
+            if box == "archive":
+                continue
+            n = len([f for f in os.listdir(os.path.join(INBOX_DIR, box)) if f.startswith("msg-")])
+            if n:
+                pending[box] = n
+        arch = os.path.join(INBOX_DIR, "archive")
+        for f in sorted(os.listdir(arch), reverse=True)[:3]:
+            to = f.rsplit(".", 1)[-1]
+            head, _, body = open(os.path.join(arch, f), errors="replace").read().partition("\n\n")
+            frm = next((l[6:] for l in head.splitlines() if l.startswith("From: ")), "?")
+            first = body.strip().splitlines()[0] if body.strip() else ""
+            intercom.append(f"{frm} → {to}: {first[:120]}")
+        intercom.reverse()
+    except Exception:
+        pass
     with LOCK:
-        STATE["timers"] = timers
+        STATE["timers"], STATE["mail_pending"], STATE["intercom"] = timers, pending, intercom
 
 
 def poll_slow():
@@ -273,7 +294,9 @@ def desk_cell(emoji, name, key, kind, tick, seed):
     """-> (8 display lines of width CELL_W+2, color)"""
     state, status, detail = agent_state(key, kind)
     inner, color = person_cell(state, tick, seed, status, detail)
-    title = f" {emoji} {name} "
+    with LOCK:
+        mail = STATE["mail_pending"].get(key, 0)
+    title = f" {emoji} {name} 📬 " if mail else f" {emoji} {name} "
     lines = ["┌" + dpad(title, CELL_W, center=True, fill="─") + "┐"]
     for l in inner:
         lines.append("│" + dpad(l, CELL_W) + "│")
@@ -298,6 +321,11 @@ def render_frame(tick, width=92):
             rows.append((dpad(line, width - 1) + "│", 0))
     with LOCK:
         prs, issues, ticker, err = STATE["prs"], STATE["issues"], STATE["ticker"], STATE["err"]
+        intercom = list(STATE["intercom"])
+    if intercom:
+        rows.append(("│" + dpad(" ═══ 💬 INTERCOM ", width - 2, fill="═") + "│", 0))
+        for msg in intercom:
+            rows.append(("│ " + dpad(msg, width - 4) + " │", 6))
     rows.append(("│" + dpad(" ═══ 📌 TABLEAU DU MUR ", width - 2, fill="═") + "│", 0))
     rows.append(("│ " + dpad("  ".join(prs) or "aucune PR ouverte — tout est mergé 🎉", width - 4) + " │", 5))
     rows.append(("│ " + dpad(issues or "…", width - 4) + " │", 5))
@@ -348,7 +376,8 @@ def selfcheck():
                 fails += 1
             fails += sum(1 for l in inner if dwidth(l) > CELL_W)
     with LOCK:
-        STATE.update(prs=["PR#0 🧪qa✗"], issues="issues: 0", err="boom", ticker="x" * 300)
+        STATE.update(prs=["PR#0 🧪qa✗"], issues="issues: 0", err="boom", ticker="x" * 300,
+                     mail_pending={"scout": 2}, intercom=["roast → scout: amend #1 📬", "scout → roast: done"])
     for tick in range(6):
         for line, _ in render_frame(tick, 92):
             if dwidth(line) != 92:

--- a/devtools/factory-tui/factory-tui.py
+++ b/devtools/factory-tui/factory-tui.py
@@ -278,6 +278,7 @@ def desk_cell(emoji, name, key, kind, tick, seed):
 
 
 def render_frame(tick, width=92):
+    row = lambda s: "│ " + dpad(s, width - 4) + " │"  # all content-row border math lives here
     rows = []
     t = time.strftime("%H:%M:%S")
     title = "─ 🏭 NOTIFICATOR DEV FACTORY "
@@ -287,19 +288,16 @@ def render_frame(tick, width=92):
         chunk = ROSTER[start:start + per_row]
         cells = [desk_cell(e, n, k, kind, tick, start + i) for i, (k, e, n, kind) in enumerate(chunk)]
         for li in range(8):
-            line = "│ "
-            for cl, _ in cells:
-                line += cl[li] + " "
-            rows.append((dpad(line, width - 1) + "│", 0))
+            rows.append((row(" ".join(cl[li] for cl, _ in cells)), 0))
     with LOCK:
         prs, issues, ticker, err = STATE["prs"], STATE["issues"], STATE["ticker"], STATE["err"]
     rows.append(("│" + dpad(" ═══ 📌 TABLEAU DU MUR ", width - 2, fill="═") + "│", 0))
-    rows.append(("│ " + dpad("  ".join(prs) or "aucune PR ouverte — tout est mergé 🎉", width - 4) + " │", 5))
-    rows.append(("│ " + dpad(issues or "…", width - 4) + " │", 5))
+    rows.append((row("  ".join(prs) or "aucune PR ouverte — tout est mergé 🎉"), 5))
+    rows.append((row(issues or "…"), 5))
     off = tick % max(1, len(ticker)) if len(ticker) > width - 12 else 0
-    rows.append(("│ 📻 " + dpad(ticker[off:off + width - 8] or "silence radio", width - 8) + "│", 6))
+    rows.append((row("📻 " + (ticker[off:] or "silence radio")), 6))
     if err:
-        rows.append(("│ ⚠ " + dpad(err, width - 6) + "│", 4))
+        rows.append((row("⚠ " + err), 4))
     rows.append(("└" + "─" * (width - 2) + "┘", 0))
     return rows
 

--- a/devtools/factory-tui/factory-tui.py
+++ b/devtools/factory-tui/factory-tui.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
-"""NOTIFICATOR DEV FACTORY — top-down real-time view of the agent office.
+"""NOTIFICATOR DEV FACTORY — gamified real-time view of the agent office.
 
-Zero dependencies (stdlib curses). Data: `looper ps`, systemd user timers/services,
-`gh` (PRs/issues), and the newest agent log as a chatter ticker.
+Little ASCII people at their desks: screens scroll when they code, coffee
+steams on breaks, zzZ floats while they sleep, and screens flash on failures.
+Zero dependencies (stdlib curses). Data: `looper ps`, systemd user
+timers/services, `gh` (PRs/issues), newest agent log as chatter ticker.
 
 Run:      python3 factory-tui.py
 Test:     python3 factory-tui.py --once     (one frame, no curses)
@@ -12,6 +14,7 @@ import curses
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 import threading
@@ -20,6 +23,40 @@ import unicodedata
 
 LOG_DIR = os.environ.get("FACTORY_LOG_DIR", os.path.expanduser("~/.claude-agents/notificator/logs"))
 REPO = os.environ.get("FACTORY_REPO", "SoulKyu/notificator")
+POLL_FAST, POLL_MED, POLL_SLOW = 3, 10, 45
+
+# desk order: (key, emoji, name, kind)  kind: looper-role | systemd unit | virtual
+ROSTER = [
+    ("scout",       "🔍", "SCOUT",  "svc:notificator-scout"),
+    ("roast",       "🔥", "ROAST",  "virtual:scout-log"),
+    ("coordinator", "🧭", "COORD",  "looper:coordinator"),
+    ("planner",     "📐", "PLAN",   "looper:planner"),
+    ("groomer",     "📋", "GROOM",  "svc:notificator-groomer"),
+    ("worker",      "🚢", "WORKER", "looper:worker"),
+    ("reviewer",    "🔎", "REVIEW", "looper:reviewer"),
+    ("fixer",       "🔧", "FIXER",  "looper:fixer"),
+    ("qa",          "🧪", "QA",     "svc:notificator-qa"),
+    ("rebaser",     "🔀", "REBASE", "svc:notificator-rebaser"),
+    ("promoter",    "⛓", "PROMO",  "svc:notificator-promoter"),
+    ("docagent",    "📚", "DOC",    "svc:notificator-docagent"),
+    ("reporter",    "📊", "REPORT", "svc:notificator-reporter"),
+]
+TIMER_OF = {
+    "scout": "notificator-scout.timer", "roast": "notificator-scout.timer",
+    "qa": "notificator-qa.timer", "rebaser": "notificator-rebaser.timer",
+    "promoter": "notificator-promoter.timer", "groomer": "notificator-groomer.timer",
+    "docagent": "notificator-docagent.timer", "reporter": "notificator-reporter.timer",
+}
+
+STATE = {"loops": [], "svc": {}, "timers": {}, "prs": [], "issues": "", "ticker": "", "err": ""}
+LOCK = threading.Lock()
+
+
+def sh(cmd, timeout=20):
+    try:
+        return subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=timeout).stdout
+    except Exception:
+        return ""
 
 
 def dwidth(s):
@@ -39,41 +76,9 @@ def dpad(s, width, center=False, fill=" "):
         left = gap // 2
         return fill * left + out + fill * (gap - left)
     return out + fill * gap
-POLL_FAST, POLL_MED, POLL_SLOW = 3, 10, 45
-
-# desk order: (key, emoji, name, kind)  kind: looper-role | systemd unit name
-ROSTER = [
-    ("scout",       "🔍", "SCOUT",  "svc:notificator-scout"),
-    ("roast",       "🔥", "ROAST",  "virtual:scout-log"),
-    ("coordinator", "🧭", "COORD",  "looper:coordinator"),
-    ("planner",     "📐", "PLAN",   "looper:planner"),
-    ("groomer",     "📋", "GROOM",  "svc:notificator-groomer"),
-    ("worker",      "🚢", "WORKER", "looper:worker"),
-    ("reviewer",    "🔎", "REVIEW", "looper:reviewer"),
-    ("fixer",       "🔧", "FIXER",  "looper:fixer"),
-    ("qa",          "🧪", "QA",     "svc:notificator-qa"),
-    ("rebaser",     "🔀", "REBASE", "svc:notificator-rebaser"),
-    ("promoter",    "⛓", "PROMO",  "svc:notificator-promoter"),
-    ("docagent",    "📚", "DOC",    "svc:notificator-docagent"),
-    ("reporter",    "📊", "REPORT", "svc:notificator-reporter"),
-]
-TIMER_OF = {  # agent key -> systemd timer (for break countdowns)
-    "scout": "notificator-scout.timer", "roast": "notificator-scout.timer",
-    "qa": "notificator-qa.timer", "rebaser": "notificator-rebaser.timer",
-    "promoter": "notificator-promoter.timer", "groomer": "notificator-groomer.timer",
-    "docagent": "notificator-docagent.timer", "reporter": "notificator-reporter.timer",
-}
-
-STATE = {"loops": [], "svc": {}, "timers": {}, "prs": [], "issues": "", "ticker": "", "err": ""}
-LOCK = threading.Lock()
 
 
-def sh(cmd, timeout=20):
-    try:
-        return subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=timeout).stdout
-    except Exception:
-        return ""
-
+# ── data pollers ────────────────────────────────────────────────────────────
 
 def poll_fast():
     loops = []
@@ -105,7 +110,6 @@ def poll_med():
         m = re.search(r"(\S+ \S+ \S+ \S+)\s+(.+?)\s+(?:\S+ \S+ \S+ \S+|-)\s+(?:.+?)\s+(notificator-\S+\.timer)", line)
         if m:
             timers[m.group(3)] = m.group(2).strip()
-    # ticker: freshest log's informative tail
     try:
         logs = sorted((os.path.join(LOG_DIR, f) for f in os.listdir(LOG_DIR)), key=os.path.getmtime)
         if logs:
@@ -122,7 +126,7 @@ def poll_med():
 
 def poll_slow():
     prs = []
-    out = sh(f"gh pr list -R {REPO} --state open --json number,title,labels,mergeable 2>/dev/null", 30)
+    out = sh(f"gh pr list -R {shlex.quote(REPO)} --state open --json number,title,labels,mergeable 2>/dev/null", 30)
     try:
         for p in json.loads(out or "[]"):
             labels = {l["name"] for l in p["labels"]}
@@ -133,7 +137,7 @@ def poll_slow():
             prs.append(f"PR#{p['number']} {tag}")
     except Exception:
         pass
-    out = sh(f"gh issue list -R {REPO} --state open --json labels 2>/dev/null", 30)
+    out = sh(f"gh issue list -R {shlex.quote(REPO)} --state open --json labels 2>/dev/null", 30)
     try:
         iss = json.loads(out or "[]")
         held = sum(1 for i in iss if any(l["name"] == "looper:hold" for l in i["labels"]))
@@ -161,14 +165,70 @@ def poller():
         time.sleep(1)
 
 
-TYPING = ["⌨ tak", "⌨ tak·", "⌨ tak··", "⌨ tak···"]
-COFFEE = ["☕", "☕~", "☕~~", "☕~"]
-SLEEP = ["💤", "z", "zZ", "zZz"]
-FIRE = ["🔥", "‼️"]
+# ── little people ───────────────────────────────────────────────────────────
+# Each state renders the inside of a desk cell: monitor (10 wide), a person,
+# and a status line. All through dpad() — emoji are double width.
+
+CODE_CHARS = "░▒▓█▓▒"
 
 
-def agent_state(key, kind, tick):
-    """-> (icon, line1, line2, color)  color: 1 ok/work 2 break 3 sleep 4 error"""
+def screen_content(tick, seed, width=8):
+    """Scrolling pseudo-code on the monitor."""
+    return "".join(CODE_CHARS[(tick + seed * 7 + i * 3) % len(CODE_CHARS)] for i in range(width))
+
+
+def person_cell(state, tick, seed, status, detail):
+    """-> (5 inner lines, color) for a desk interior."""
+    t = tick + seed * 5
+    if state == "work":
+        arms = ["/|    |\\", "\\|    |/"][t % 2]
+        bubble = ["tak", "tak·", "tak··", "  ♪" if (t % 37) < 3 else "tak···"][t % 4]
+        return [
+            " ┌────────┐",
+            " │" + screen_content(t, seed) + "│ " + bubble,
+            " └────────┘",
+            "   (^_^)⌨",
+            "   " + arms,
+        ], 1
+    if state == "break":
+        steam = ["  ~", " ~ ", "~  ", " ~ "][t % 4]
+        return [
+            " ┌────────┐",
+            " │  zZ off │".replace("zZ", "  "),
+            " └────────┘" + steam,
+            "   (u_u)☕",
+            "   /|    |\\",
+        ], 2
+    if state == "sleep":
+        zz = ["z", "zZ", "zzZ", " zZ"][t % 4]
+        return [
+            " ┌────────┐",
+            " │········│",
+            " └────────┘  " + zz,
+            "   (-_-)",
+            "   =====  ",
+        ], 3
+    if state == "error":
+        flash = ["!ERROR!", "       "][t % 2]
+        return [
+            " ┌────────┐",
+            " │" + dpad(flash, 8, center=True) + "│ 🔥",
+            " └────────┘",
+            "   (>_<)!!",
+            "   /|    |\\",
+        ], 4
+    # wait / queued
+    return [
+        " ┌────────┐",
+        " │ ▁▁▁▁▁▁ │ …",
+        " └────────┘",
+        "   (o_o)",
+        "   /|    |\\",
+    ], 2
+
+
+def agent_state(key, kind):
+    """-> (state, status, detail)"""
     with LOCK:
         loops, svc, timers, ticker = STATE["loops"], dict(STATE["svc"]), dict(STATE["timers"]), STATE["ticker"]
     nxt = timers.get(TIMER_OF.get(key, ""), "")
@@ -177,59 +237,67 @@ def agent_state(key, kind, tick):
         for lp in loops:
             if lp["type"] == role:
                 tgt = lp["target"].split("/")[-1]
-                if lp["status"] in ("running", "queued"):
-                    return TYPING[tick % 4], f"{lp['step'][:10]}", tgt[:10], 1
-                return "🤔", lp["status"][:10], tgt[:10], 2
-        return COFFEE[tick % 4], "veille", "poll 30s", 2
-    if kind == "virtual:scout-log":  # roast rides the scout service
+                if lp["status"] == "running":
+                    return "work", lp["step"], tgt
+                if lp["status"] == "queued":
+                    return "wait", "en file", tgt
+                return "wait", lp["status"], tgt
+        return "break", "veille", "poll 30s"
+    if kind == "virtual:scout-log":
         s = svc.get("notificator-scout", {})
-        if s.get("ActiveState") == "activating" or s.get("ActiveState") == "active":
+        if s.get("ActiveState") in ("active", "activating"):
             if "roast" in ticker:
-                return TYPING[tick % 4], "roast en", "cours!", 1
-            return SLEEP[tick % 4], "attend le", "scout", 3
-        return COFFEE[tick % 4], "pause", nxt[:10] or "?", 2
+                return "work", "roast!", "issues"
+            return "wait", "attend", "le scout"
+        return "break", "pause", nxt or "?"
     unit = kind.split(":")[1]
     s = svc.get(unit, {})
     if s.get("ActiveState") in ("active", "activating"):
-        return TYPING[tick % 4], "run en", "cours", 1
+        return "work", "run", "en cours"
     if s.get("Result") not in ("success", "", None):
-        return FIRE[tick % 2], "échec!", s.get("Result", "")[:10], 4
-    if nxt and ("h" in nxt.split()[0] if nxt.split() else False):
-        return SLEEP[tick % 4], "dort", nxt[:10], 3
-    return COFFEE[tick % 4], "pause", nxt[:10] or "?", 2
+        return "error", "échec", s.get("Result", "")
+    if nxt and any(u in nxt.split()[0] for u in ("h", "day", "week")) if nxt.split() else False:
+        return "sleep", "dort", nxt
+    return "break", "pause", nxt or "?"
 
 
-def render_frame(tick, width=78):
+CELL_W = 20  # inner width of a desk cell
+
+
+def desk_cell(emoji, name, key, kind, tick, seed):
+    """-> (8 display lines of width CELL_W+2, color)"""
+    state, status, detail = agent_state(key, kind)
+    inner, color = person_cell(state, tick, seed, status, detail)
+    title = f" {emoji} {name} "
+    lines = ["┌" + dpad(title, CELL_W, center=True, fill="─") + "┐"]
+    for l in inner:
+        lines.append("│" + dpad(l, CELL_W) + "│")
+    lines.append("│" + dpad(" " + (status + " " + detail).strip(), CELL_W) + "│")
+    lines.append("└" + "─" * CELL_W + "┘")
+    return lines, color
+
+
+def render_frame(tick, width=92):
     rows = []
     t = time.strftime("%H:%M:%S")
-    rows.append(("┌─ NOTIFICATOR DEV FACTORY " + "─" * (width - 38) + f" {t} ─┐", 0))
-    desks_per_row = max(2, (width - 4) // 13)
-    for start in range(0, len(ROSTER), desks_per_row):
-        chunk = ROSTER[start:start + desks_per_row]
-        cells = []
-        for key, emoji, name, kind in chunk:
-            icon, l1, l2, color = agent_state(key, kind, tick)
-            cells.append((f"{emoji} {name}", icon, l1, l2, color))
-        for li in range(4):
+    title = "─ 🏭 NOTIFICATOR DEV FACTORY "
+    rows.append(("┌" + dpad(title, width - 13, fill="─") + f" {t} ─┐", 0))
+    per_row = max(1, (width - 4) // (CELL_W + 3))
+    for start in range(0, len(ROSTER), per_row):
+        chunk = ROSTER[start:start + per_row]
+        cells = [desk_cell(e, n, k, kind, tick, start + i) for i, (k, e, n, kind) in enumerate(chunk)]
+        for li in range(8):
             line = "│ "
-            for c in cells:
-                if li == 0:
-                    line += "┌" + "─" * 10 + "┐ "
-                elif li == 1:
-                    line += "│" + dpad(c[0], 10) + "│ "
-                elif li == 2:
-                    line += "│" + dpad(c[1] + " " + c[2], 10) + "│ "
-                else:
-                    line += "└" + dpad(c[3], 10, center=True, fill="─") + "┘ "
+            for cl, _ in cells:
+                line += cl[li] + " "
             rows.append((dpad(line, width - 1) + "│", 0))
-        rows.append(("│" + " " * (width - 2) + "│", 0))
     with LOCK:
         prs, issues, ticker, err = STATE["prs"], STATE["issues"], STATE["ticker"], STATE["err"]
-    rows.append(("│ ── TABLEAU " + "─" * (width - 14) + " │", 0))
-    rows.append(("│ " + dpad("  ".join(prs) or "aucune PR ouverte", width - 4) + " │", 5))
+    rows.append(("│" + dpad(" ═══ 📌 TABLEAU DU MUR ", width - 2, fill="═") + "│", 0))
+    rows.append(("│ " + dpad("  ".join(prs) or "aucune PR ouverte — tout est mergé 🎉", width - 4) + " │", 5))
     rows.append(("│ " + dpad(issues or "…", width - 4) + " │", 5))
     off = tick % max(1, len(ticker)) if len(ticker) > width - 12 else 0
-    rows.append(("│ 📻 " + dpad(ticker[off:off + width - 7] or "silence radio", width - 8) + "│", 6))
+    rows.append(("│ 📻 " + dpad(ticker[off:off + width - 8] or "silence radio", width - 8) + "│", 6))
     if err:
         rows.append(("│ ⚠ " + dpad(err, width - 6) + "│", 4))
     rows.append(("└" + "─" * (width - 2) + "┘", 0))
@@ -250,7 +318,7 @@ def main_curses(scr):
             return
         h, w = scr.getmaxyx()
         scr.erase()
-        for y, (line, color) in enumerate(render_frame(tick, min(w - 1, 100))):
+        for y, (line, color) in enumerate(render_frame(tick, min(w - 1, 120))):
             if y >= h - 1:
                 break
             try:

--- a/devtools/factory-tui/factory-tui.py
+++ b/devtools/factory-tui/factory-tui.py
@@ -127,6 +127,11 @@ def poll_med():
 def poll_slow():
     prs = []
     out = sh(f"gh pr list -R {shlex.quote(REPO)} --state open --json number,title,labels,mergeable 2>/dev/null", 30)
+    if not out.strip():
+        # `gh` returns "[]" for zero PRs — an empty string means GitHub is unreachable
+        with LOCK:
+            STATE["prs"], STATE["issues"] = ["(github injoignable)"], "(github injoignable)"
+        return
     try:
         for p in json.loads(out or "[]"):
             labels = {l["name"] for l in p["labels"]}
@@ -194,7 +199,7 @@ def person_cell(state, tick, seed, status, detail):
         steam = ["  ~", " ~ ", "~  ", " ~ "][t % 4]
         return [
             " ┌────────┐",
-            " │  zZ off │".replace("zZ", "  "),
+            " │" + dpad("off", 8, center=True) + "│",
             " └────────┘" + steam,
             "   (u_u)☕",
             "   /|    |\\",
@@ -278,7 +283,6 @@ def desk_cell(emoji, name, key, kind, tick, seed):
 
 
 def render_frame(tick, width=92):
-    row = lambda s: "│ " + dpad(s, width - 4) + " │"  # all content-row border math lives here
     rows = []
     t = time.strftime("%H:%M:%S")
     title = "─ 🏭 NOTIFICATOR DEV FACTORY "
@@ -288,16 +292,19 @@ def render_frame(tick, width=92):
         chunk = ROSTER[start:start + per_row]
         cells = [desk_cell(e, n, k, kind, tick, start + i) for i, (k, e, n, kind) in enumerate(chunk)]
         for li in range(8):
-            rows.append((row(" ".join(cl[li] for cl, _ in cells)), 0))
+            line = "│ "
+            for cl, _ in cells:
+                line += cl[li] + " "
+            rows.append((dpad(line, width - 1) + "│", 0))
     with LOCK:
         prs, issues, ticker, err = STATE["prs"], STATE["issues"], STATE["ticker"], STATE["err"]
     rows.append(("│" + dpad(" ═══ 📌 TABLEAU DU MUR ", width - 2, fill="═") + "│", 0))
-    rows.append((row("  ".join(prs) or "aucune PR ouverte — tout est mergé 🎉"), 5))
-    rows.append((row(issues or "…"), 5))
+    rows.append(("│ " + dpad("  ".join(prs) or "aucune PR ouverte — tout est mergé 🎉", width - 4) + " │", 5))
+    rows.append(("│ " + dpad(issues or "…", width - 4) + " │", 5))
     off = tick % max(1, len(ticker)) if len(ticker) > width - 12 else 0
-    rows.append((row("📻 " + (ticker[off:] or "silence radio")), 6))
+    rows.append(("│ 📻 " + dpad(ticker[off:off + width - 8] or "silence radio", width - 6) + "│", 6))
     if err:
-        rows.append((row("⚠ " + err), 4))
+        rows.append(("│ ⚠ " + dpad(err, width - 5) + "│", 4))
     rows.append(("└" + "─" * (width - 2) + "┘", 0))
     return rows
 
@@ -328,7 +335,32 @@ def main_curses(scr):
         tick += 1
 
 
+def selfcheck():
+    """Alignment invariants: monitor segment = 11 cols in every state, frame rows all equal."""
+    fails = 0
+    for state in ("work", "break", "sleep", "error", "wait"):
+        for tick in range(8):
+            inner, _ = person_cell(state, tick, 3, "s", "d")
+            row = inner[1]
+            seg = row[:row.index("│", row.index("│") + 1) + 1]
+            if dwidth(seg) != 11:
+                print(f"FAIL {state} t{tick}: monitor segment {dwidth(seg)} cols: {seg!r}")
+                fails += 1
+            fails += sum(1 for l in inner if dwidth(l) > CELL_W)
+    with LOCK:
+        STATE.update(prs=["PR#0 🧪qa✗"], issues="issues: 0", err="boom", ticker="x" * 300)
+    for tick in range(6):
+        for line, _ in render_frame(tick, 92):
+            if dwidth(line) != 92:
+                print(f"FAIL row {dwidth(line)} cols: {line!r}")
+                fails += 1
+    print("selfcheck: OK" if fails == 0 else f"selfcheck: {fails} FAILURES")
+    return fails
+
+
 if __name__ == "__main__":
+    if "--check" in sys.argv:
+        sys.exit(1 if selfcheck() else 0)
     threading.Thread(target=poller, daemon=True).start()
     if "--once" in sys.argv:
         time.sleep(8)  # let pollers fill (gh calls can be slow)
@@ -336,4 +368,7 @@ if __name__ == "__main__":
             print(line)
         sys.exit(0)
     time.sleep(1)
-    curses.wrapper(main_curses)
+    try:
+        curses.wrapper(main_curses)
+    except KeyboardInterrupt:
+        pass

--- a/devtools/factory-tui/factory-tui.py
+++ b/devtools/factory-tui/factory-tui.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""NOTIFICATOR DEV FACTORY — top-down real-time view of the agent office.
+
+Zero dependencies (stdlib curses). Data: `looper ps`, systemd user timers/services,
+`gh` (PRs/issues), and the newest agent log as a chatter ticker.
+
+Run:      python3 factory-tui.py
+Test:     python3 factory-tui.py --once     (one frame, no curses)
+Keys:     q quit
+"""
+import curses
+import json
+import os
+import re
+import subprocess
+import sys
+import threading
+import time
+import unicodedata
+
+LOG_DIR = os.environ.get("FACTORY_LOG_DIR", os.path.expanduser("~/.claude-agents/notificator/logs"))
+REPO = os.environ.get("FACTORY_REPO", "SoulKyu/notificator")
+
+
+def dwidth(s):
+    """Terminal display width (emoji and CJK count double)."""
+    return sum(2 if unicodedata.east_asian_width(c) in "WF" else 1 for c in s)
+
+
+def dpad(s, width, center=False, fill=" "):
+    """Truncate/pad to an exact display width."""
+    out = ""
+    for c in s:
+        if dwidth(out + c) > width:
+            break
+        out += c
+    gap = width - dwidth(out)
+    if center:
+        left = gap // 2
+        return fill * left + out + fill * (gap - left)
+    return out + fill * gap
+POLL_FAST, POLL_MED, POLL_SLOW = 3, 10, 45
+
+# desk order: (key, emoji, name, kind)  kind: looper-role | systemd unit name
+ROSTER = [
+    ("scout",       "🔍", "SCOUT",  "svc:notificator-scout"),
+    ("roast",       "🔥", "ROAST",  "virtual:scout-log"),
+    ("coordinator", "🧭", "COORD",  "looper:coordinator"),
+    ("planner",     "📐", "PLAN",   "looper:planner"),
+    ("groomer",     "📋", "GROOM",  "svc:notificator-groomer"),
+    ("worker",      "🚢", "WORKER", "looper:worker"),
+    ("reviewer",    "🔎", "REVIEW", "looper:reviewer"),
+    ("fixer",       "🔧", "FIXER",  "looper:fixer"),
+    ("qa",          "🧪", "QA",     "svc:notificator-qa"),
+    ("rebaser",     "🔀", "REBASE", "svc:notificator-rebaser"),
+    ("promoter",    "⛓", "PROMO",  "svc:notificator-promoter"),
+    ("docagent",    "📚", "DOC",    "svc:notificator-docagent"),
+    ("reporter",    "📊", "REPORT", "svc:notificator-reporter"),
+]
+TIMER_OF = {  # agent key -> systemd timer (for break countdowns)
+    "scout": "notificator-scout.timer", "roast": "notificator-scout.timer",
+    "qa": "notificator-qa.timer", "rebaser": "notificator-rebaser.timer",
+    "promoter": "notificator-promoter.timer", "groomer": "notificator-groomer.timer",
+    "docagent": "notificator-docagent.timer", "reporter": "notificator-reporter.timer",
+}
+
+STATE = {"loops": [], "svc": {}, "timers": {}, "prs": [], "issues": "", "ticker": "", "err": ""}
+LOCK = threading.Lock()
+
+
+def sh(cmd, timeout=20):
+    try:
+        return subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=timeout).stdout
+    except Exception:
+        return ""
+
+
+def poll_fast():
+    loops = []
+    out = sh("looper ps 2>/dev/null")
+    for line in out.splitlines()[2:]:
+        parts = line.split()
+        if len(parts) >= 7 and parts[1] != "-":
+            loops.append({"type": parts[1], "target": parts[2], "step": parts[3], "status": parts[6]})
+    svc = {}
+    units = " ".join(k.split(":")[1] + ".service" for _, _, _, k in ROSTER if k.startswith("svc:"))
+    out = sh(f"systemctl --user show {units} -p Id,ActiveState,Result 2>/dev/null")
+    cur = {}
+    for line in out.splitlines() + [""]:
+        if not line.strip():
+            if "Id" in cur:
+                svc[cur["Id"].replace(".service", "")] = cur
+            cur = {}
+        elif "=" in line:
+            k, v = line.split("=", 1)
+            cur[k] = v
+    with LOCK:
+        STATE["loops"], STATE["svc"] = loops, svc
+
+
+def poll_med():
+    timers = {}
+    out = sh("systemctl --user list-timers 'notificator-*' --all --no-pager --plain 2>/dev/null")
+    for line in out.splitlines():
+        m = re.search(r"(\S+ \S+ \S+ \S+)\s+(.+?)\s+(?:\S+ \S+ \S+ \S+|-)\s+(?:.+?)\s+(notificator-\S+\.timer)", line)
+        if m:
+            timers[m.group(3)] = m.group(2).strip()
+    # ticker: freshest log's informative tail
+    try:
+        logs = sorted((os.path.join(LOG_DIR, f) for f in os.listdir(LOG_DIR)), key=os.path.getmtime)
+        if logs:
+            tail = open(logs[-1], errors="replace").read().strip().splitlines()
+            name = os.path.basename(logs[-1]).rsplit("-", 1)[0]
+            line = next((l for l in reversed(tail) if l.strip() and "LOOPER_RESULT" not in l), "")
+            with LOCK:
+                STATE["ticker"] = f"[{name}] {line.strip()[:200]}"
+    except Exception:
+        pass
+    with LOCK:
+        STATE["timers"] = timers
+
+
+def poll_slow():
+    prs = []
+    out = sh(f"gh pr list -R {REPO} --state open --json number,title,labels,mergeable 2>/dev/null", 30)
+    try:
+        for p in json.loads(out or "[]"):
+            labels = {l["name"] for l in p["labels"]}
+            tag = ("💥conflit" if p.get("mergeable") == "CONFLICTING" else
+                   "🧪qa✗" if "qa:failed" in labels else
+                   "✅qa" if "qa:passed" in labels else
+                   "📐spec" if any("spec" in l for l in labels) else "👀review")
+            prs.append(f"PR#{p['number']} {tag}")
+    except Exception:
+        pass
+    out = sh(f"gh issue list -R {REPO} --state open --json labels 2>/dev/null", 30)
+    try:
+        iss = json.loads(out or "[]")
+        held = sum(1 for i in iss if any(l["name"] == "looper:hold" for l in i["labels"]))
+        agent = sum(1 for i in iss if any(l["name"] == "agent:proposed" for l in i["labels"]))
+        with LOCK:
+            STATE["issues"] = f"issues: {len(iss)} open · {agent} agents · {held} hold"
+    except Exception:
+        pass
+    with LOCK:
+        STATE["prs"] = prs
+
+
+def poller():
+    last = {"fast": 0, "med": 0, "slow": 0}
+    while True:
+        now = time.time()
+        for name, interval, fn in (("fast", POLL_FAST, poll_fast), ("med", POLL_MED, poll_med), ("slow", POLL_SLOW, poll_slow)):
+            if now - last[name] >= interval:
+                try:
+                    fn()
+                except Exception as e:
+                    with LOCK:
+                        STATE["err"] = str(e)[:80]
+                last[name] = now
+        time.sleep(1)
+
+
+TYPING = ["⌨ tak", "⌨ tak·", "⌨ tak··", "⌨ tak···"]
+COFFEE = ["☕", "☕~", "☕~~", "☕~"]
+SLEEP = ["💤", "z", "zZ", "zZz"]
+FIRE = ["🔥", "‼️"]
+
+
+def agent_state(key, kind, tick):
+    """-> (icon, line1, line2, color)  color: 1 ok/work 2 break 3 sleep 4 error"""
+    with LOCK:
+        loops, svc, timers, ticker = STATE["loops"], dict(STATE["svc"]), dict(STATE["timers"]), STATE["ticker"]
+    nxt = timers.get(TIMER_OF.get(key, ""), "")
+    if kind.startswith("looper:"):
+        role = kind.split(":")[1]
+        for lp in loops:
+            if lp["type"] == role:
+                tgt = lp["target"].split("/")[-1]
+                if lp["status"] in ("running", "queued"):
+                    return TYPING[tick % 4], f"{lp['step'][:10]}", tgt[:10], 1
+                return "🤔", lp["status"][:10], tgt[:10], 2
+        return COFFEE[tick % 4], "veille", "poll 30s", 2
+    if kind == "virtual:scout-log":  # roast rides the scout service
+        s = svc.get("notificator-scout", {})
+        if s.get("ActiveState") == "activating" or s.get("ActiveState") == "active":
+            if "roast" in ticker:
+                return TYPING[tick % 4], "roast en", "cours!", 1
+            return SLEEP[tick % 4], "attend le", "scout", 3
+        return COFFEE[tick % 4], "pause", nxt[:10] or "?", 2
+    unit = kind.split(":")[1]
+    s = svc.get(unit, {})
+    if s.get("ActiveState") in ("active", "activating"):
+        return TYPING[tick % 4], "run en", "cours", 1
+    if s.get("Result") not in ("success", "", None):
+        return FIRE[tick % 2], "échec!", s.get("Result", "")[:10], 4
+    if nxt and ("h" in nxt.split()[0] if nxt.split() else False):
+        return SLEEP[tick % 4], "dort", nxt[:10], 3
+    return COFFEE[tick % 4], "pause", nxt[:10] or "?", 2
+
+
+def render_frame(tick, width=78):
+    rows = []
+    t = time.strftime("%H:%M:%S")
+    rows.append(("┌─ NOTIFICATOR DEV FACTORY " + "─" * (width - 38) + f" {t} ─┐", 0))
+    desks_per_row = max(2, (width - 4) // 13)
+    for start in range(0, len(ROSTER), desks_per_row):
+        chunk = ROSTER[start:start + desks_per_row]
+        cells = []
+        for key, emoji, name, kind in chunk:
+            icon, l1, l2, color = agent_state(key, kind, tick)
+            cells.append((f"{emoji} {name}", icon, l1, l2, color))
+        for li in range(4):
+            line = "│ "
+            for c in cells:
+                if li == 0:
+                    line += "┌" + "─" * 10 + "┐ "
+                elif li == 1:
+                    line += "│" + dpad(c[0], 10) + "│ "
+                elif li == 2:
+                    line += "│" + dpad(c[1] + " " + c[2], 10) + "│ "
+                else:
+                    line += "└" + dpad(c[3], 10, center=True, fill="─") + "┘ "
+            rows.append((dpad(line, width - 1) + "│", 0))
+        rows.append(("│" + " " * (width - 2) + "│", 0))
+    with LOCK:
+        prs, issues, ticker, err = STATE["prs"], STATE["issues"], STATE["ticker"], STATE["err"]
+    rows.append(("│ ── TABLEAU " + "─" * (width - 14) + " │", 0))
+    rows.append(("│ " + dpad("  ".join(prs) or "aucune PR ouverte", width - 4) + " │", 5))
+    rows.append(("│ " + dpad(issues or "…", width - 4) + " │", 5))
+    off = tick % max(1, len(ticker)) if len(ticker) > width - 12 else 0
+    rows.append(("│ 📻 " + dpad(ticker[off:off + width - 7] or "silence radio", width - 8) + "│", 6))
+    if err:
+        rows.append(("│ ⚠ " + dpad(err, width - 6) + "│", 4))
+    rows.append(("└" + "─" * (width - 2) + "┘", 0))
+    return rows
+
+
+def main_curses(scr):
+    curses.curs_set(0)
+    scr.nodelay(True)
+    curses.start_color()
+    curses.use_default_colors()
+    for i, fg in ((1, curses.COLOR_GREEN), (2, curses.COLOR_YELLOW), (3, curses.COLOR_BLUE),
+                  (4, curses.COLOR_RED), (5, curses.COLOR_CYAN), (6, curses.COLOR_MAGENTA)):
+        curses.init_pair(i, fg, -1)
+    tick = 0
+    while True:
+        if scr.getch() in (ord("q"), 27):
+            return
+        h, w = scr.getmaxyx()
+        scr.erase()
+        for y, (line, color) in enumerate(render_frame(tick, min(w - 1, 100))):
+            if y >= h - 1:
+                break
+            try:
+                scr.addstr(y, 0, line, curses.color_pair(color) if color else 0)
+            except curses.error:
+                pass
+        scr.refresh()
+        time.sleep(0.25)
+        tick += 1
+
+
+if __name__ == "__main__":
+    threading.Thread(target=poller, daemon=True).start()
+    if "--once" in sys.argv:
+        time.sleep(8)  # let pollers fill (gh calls can be slow)
+        for line, _ in render_frame(2):
+            print(line)
+        sys.exit(0)
+    time.sleep(1)
+    curses.wrapper(main_curses)


### PR DESCRIPTION
A zero-dependency curses dashboard showing the autonomous dev agents at work in real time — desks, coffee breaks, sleep cycles, team board (PRs/issues) and a log chatter ticker.

Lives under `devtools/` — development tooling only, never ships with the product. See `devtools/factory-tui/README.md` for data sources, env config, and the constraints future agents must preserve (stdlib-only, read-only, `--once` testable mode).

Testing: `python3 devtools/factory-tui/factory-tui.py --once` renders a frame and exits 0.