### PR TITLE
fix(webui): don't mass-resolve alerts from a failed Alertmanager source

### DIFF
--- a/internal/alertmanager/client.go
+++ b/internal/alertmanager/client.go
@@ -668,17 +668,20 @@ type SilenceWithSource struct {
 	Source  string // Name of the Alertmanager instance
 }
 
-func (mc *MultiClient) FetchAllAlerts() ([]AlertWithSource, error) {
+// FetchAllAlertsDetailed fetches alerts from every configured Alertmanager and
+// reports per-source failures instead of collapsing them into a single error,
+// so callers can tell a partial fetch from a genuinely empty one.
+func (mc *MultiClient) FetchAllAlertsDetailed() ([]AlertWithSource, map[string]error) {
 	mc.mutex.RLock()
 	defer mc.mutex.RUnlock()
 
 	var allAlerts []AlertWithSource
-	var errors []error
+	failedSources := make(map[string]error)
 
 	for name, client := range mc.clients {
 		alerts, err := client.FetchAlerts()
 		if err != nil {
-			errors = append(errors, fmt.Errorf("failed to fetch alerts from %s: %w", name, err))
+			failedSources[name] = err
 			continue
 		}
 
@@ -690,8 +693,16 @@ func (mc *MultiClient) FetchAllAlerts() ([]AlertWithSource, error) {
 		}
 	}
 
-	if len(errors) > 0 && len(allAlerts) == 0 { // If all clients failed, return the first error
-		return nil, errors[0]
+	return allAlerts, failedSources
+}
+
+func (mc *MultiClient) FetchAllAlerts() ([]AlertWithSource, error) {
+	allAlerts, failedSources := mc.FetchAllAlertsDetailed()
+
+	if len(failedSources) > 0 && len(allAlerts) == 0 { // If all clients failed, return the first error
+		for name, err := range failedSources {
+			return nil, fmt.Errorf("failed to fetch alerts from %s: %w", name, err)
+		}
 	}
 
 	return allAlerts, nil

--- a/internal/webui/services/alert_cache.go
+++ b/internal/webui/services/alert_cache.go
@@ -33,13 +33,23 @@ func transformSeverity(severity string) string {
 	}
 }
 
+// alertFetcher abstracts alertmanager.MultiClient so tests can fake fetches.
+type alertFetcher interface {
+	FetchAllAlertsDetailed() ([]alertmanager.AlertWithSource, map[string]error)
+}
+
+// maxBackendWorkers bounds concurrent backend calls spawned by a refresh cycle,
+// so a large diff cannot stampede the backend with thousands of gRPC calls.
+const maxBackendWorkers = 8
+
 type AlertCache struct {
 	mu                 sync.RWMutex
 	alerts             map[string]*webuimodels.DashboardAlert // fingerprint -> alert
 	userHiddenAlerts   map[string]map[string]bool             // userID -> fingerprint -> hidden
-	alertmanagerClient *alertmanager.MultiClient
+	alertmanagerClient alertFetcher
 	backendClient      *client.BackendClient
 	colorService       *ColorService
+	backendSem         chan struct{} // semaphore bounding refresh-triggered backend calls
 
 	// Color caching - keyed by userID then fingerprint
 	colorsMutex  sync.RWMutex
@@ -77,13 +87,21 @@ func NewAlertCache(amClient *alertmanager.MultiClient, backendClient *client.Bac
 		syncInterval = 10 * time.Second
 	}
 
+	// Avoid storing a typed-nil *MultiClient in the interface field, which would
+	// defeat the nil check in refreshAlerts.
+	var fetcher alertFetcher
+	if amClient != nil {
+		fetcher = amClient
+	}
+
 	return &AlertCache{
 		alerts:                make(map[string]*webuimodels.DashboardAlert),
 		userHiddenAlerts:      make(map[string]map[string]bool),
-		alertmanagerClient:    amClient,
+		alertmanagerClient:    fetcher,
 		backendClient:         backendClient,
 		colorService:          NewColorService(backendClient),
 		cachedColors:          make(map[string]map[string]*AlertColorResult),
+		backendSem:            make(chan struct{}, maxBackendWorkers),
 		refreshInterval:       syncInterval,
 		resolvedRetentionDays: resolvedRetentionDays,
 		newAlerts:             make([]string, 0),
@@ -142,14 +160,27 @@ func (ac *AlertCache) backgroundRefresh() {
 	}
 }
 
+// runBounded runs fn on a goroutine while holding a slot in backendSem, so at
+// most maxBackendWorkers refresh-triggered backend calls run concurrently.
+func (ac *AlertCache) runBounded(fn func()) {
+	go func() {
+		ac.backendSem <- struct{}{}
+		defer func() { <-ac.backendSem }()
+		fn()
+	}()
+}
+
 func (ac *AlertCache) refreshAlerts() {
 	if ac.alertmanagerClient == nil {
 		return
 	}
 
-	alertsWithSource, err := ac.alertmanagerClient.FetchAllAlerts()
-	if err != nil {
-		log.Printf("Failed to fetch alerts: %v", err)
+	alertsWithSource, fetchErrors := ac.alertmanagerClient.FetchAllAlertsDetailed()
+	for source, fetchErr := range fetchErrors {
+		log.Printf("Alert cache refresh: failed to fetch alerts from %s, keeping its cached alerts untouched: %v", source, fetchErr)
+	}
+	if len(alertsWithSource) == 0 && len(fetchErrors) > 0 {
+		// No source returned anything usable; leave the cache as-is.
 		return
 	}
 
@@ -178,13 +209,13 @@ func (ac *AlertCache) refreshAlerts() {
 			newAlertsForSSE = append(newAlertsForSSE, dashAlert)
 
 			// Capture alert fired event for statistics
-			go func(alert *webuimodels.DashboardAlert) {
+			ac.runBounded(func() {
 				if ac.backendClient != nil && ac.backendClient.IsConnected() {
-					if err := ac.backendClient.CaptureAlertFired(alert); err != nil {
-						log.Printf("Failed to capture alert fired statistics for %s: %v", alert.Fingerprint, err)
+					if err := ac.backendClient.CaptureAlertFired(dashAlert); err != nil {
+						log.Printf("Failed to capture alert fired statistics for %s: %v", dashAlert.Fingerprint, err)
 					}
 				}
-			}(dashAlert)
+			})
 
 		} else {
 			// Check if alert changed before updating
@@ -199,6 +230,13 @@ func (ac *AlertCache) refreshAlerts() {
 	var removedFingerprints []string
 	for fingerprint, alert := range ac.alerts {
 		if !currentFingerprints[fingerprint] {
+			// A fingerprint missing from a source that failed to answer this cycle
+			// says nothing about the alert's state: keep it untouched instead of
+			// mass-resolving an entire unreachable Alertmanager.
+			if _, sourceFailed := fetchErrors[alert.Source]; sourceFailed {
+				continue
+			}
+
 			log.Printf("Alert cache: marking alert %s as resolved (not found in current fetch)", fingerprint)
 			alert.IsResolved = true
 			alert.ResolvedAt = time.Now()
@@ -206,19 +244,19 @@ func (ac *AlertCache) refreshAlerts() {
 			alert.EndsAt = alert.ResolvedAt
 
 			// Update alert resolved event for statistics
-			go func(resolvedAlert *webuimodels.DashboardAlert) {
+			ac.runBounded(func() {
 				if ac.backendClient != nil && ac.backendClient.IsConnected() {
-					if err := ac.backendClient.UpdateAlertResolved(resolvedAlert); err != nil {
-						log.Printf("Failed to update alert resolved statistics for %s: %v", resolvedAlert.Fingerprint, err)
+					if err := ac.backendClient.UpdateAlertResolved(alert); err != nil {
+						log.Printf("Failed to update alert resolved statistics for %s: %v", alert.Fingerprint, err)
 					}
 				}
-			}(alert)
+			})
 
 			// Capture complete alert data with comments and acknowledgments for backend storage.
 			// Copy the struct before spawning the goroutine so it operates on a snapshot,
 			// not the cache-resident pointer which may be mutated by concurrent writers.
 			alertCopy := *alert
-			go ac.storeResolvedAlertInBackend(&alertCopy)
+			ac.runBounded(func() { ac.storeResolvedAlertInBackend(&alertCopy) })
 
 			delete(ac.alerts, fingerprint)
 

--- a/internal/webui/services/alert_cache_test.go
+++ b/internal/webui/services/alert_cache_test.go
@@ -1,9 +1,12 @@
 package services
 
 import (
+	"errors"
 	"testing"
 	"time"
 
+	"notificator/internal/alertmanager"
+	"notificator/internal/models"
 	webuimodels "notificator/internal/webui/models"
 )
 
@@ -121,8 +124,8 @@ func TestAlertCache_UpdatedAtTracking(t *testing.T) {
 			Status: webuimodels.AlertStatus{
 				State: "firing", // Same state
 			},
-			IsAcknowledged: false,           // Same
-			CommentCount:   0,               // Same
+			IsAcknowledged: false,                // Same
+			CommentCount:   0,                    // Same
 			Summary:        "Test alert summary", // Same
 		}
 
@@ -804,6 +807,103 @@ func TestAlertCache_SSEPubSub(t *testing.T) {
 
 		if cache.GetSubscriberCount() != 0 {
 			t.Errorf("Expected 0 subscribers, got %d", cache.GetSubscriberCount())
+		}
+	})
+}
+
+// fakeAlertFetcher lets tests control what a refresh cycle sees per source.
+type fakeAlertFetcher struct {
+	alerts      []alertmanager.AlertWithSource
+	fetchErrors map[string]error
+}
+
+func (f *fakeAlertFetcher) FetchAllAlertsDetailed() ([]alertmanager.AlertWithSource, map[string]error) {
+	return f.alerts, f.fetchErrors
+}
+
+func TestAlertCache_RefreshWithPartialFetchFailure(t *testing.T) {
+	newAlert := func(name, source string) alertmanager.AlertWithSource {
+		return alertmanager.AlertWithSource{
+			Alert: models.Alert{
+				Labels:   map[string]string{"alertname": name},
+				Status:   models.AlertStatus{State: "firing"},
+				StartsAt: time.Now().Add(-time.Hour),
+			},
+			Source: source,
+		}
+	}
+
+	prodAlert := newAlert("ProdAlert", "prod")
+	stagingAlert := newAlert("StagingAlert", "staging")
+
+	cache := NewAlertCache(nil, nil, 90, 10*time.Second)
+	prodFingerprint := cache.convertToDashboardAlert(prodAlert.Alert, prodAlert.Source).Fingerprint
+	stagingFingerprint := cache.convertToDashboardAlert(stagingAlert.Alert, stagingAlert.Source).Fingerprint
+
+	// Seed the cache with one alert per source via a healthy fetch.
+	fetcher := &fakeAlertFetcher{alerts: []alertmanager.AlertWithSource{prodAlert, stagingAlert}}
+	cache.alertmanagerClient = fetcher
+	cache.refreshAlerts()
+
+	if _, ok := cache.GetAlert(prodFingerprint); !ok {
+		t.Fatal("prod alert should be cached after healthy refresh")
+	}
+	if _, ok := cache.GetAlert(stagingFingerprint); !ok {
+		t.Fatal("staging alert should be cached after healthy refresh")
+	}
+
+	t.Run("Alerts from a failed source survive the cycle", func(t *testing.T) {
+		fetcher.alerts = []alertmanager.AlertWithSource{stagingAlert}
+		fetcher.fetchErrors = map[string]error{"prod": errors.New("connection refused")}
+		cache.refreshAlerts()
+
+		prodCached, ok := cache.GetAlert(prodFingerprint)
+		if !ok {
+			t.Fatal("prod alert must not be removed when its source failed to answer")
+		}
+		if prodCached.IsResolved || prodCached.Status.State == "resolved" {
+			t.Error("prod alert must not be marked resolved when its source failed to answer")
+		}
+		if _, ok := cache.GetAlert(stagingFingerprint); !ok {
+			t.Error("staging alert should still be cached")
+		}
+	})
+
+	t.Run("Alerts from a healthy source still resolve normally", func(t *testing.T) {
+		// staging no longer reports its original alert while prod is still down.
+		fetcher.alerts = []alertmanager.AlertWithSource{newAlert("StagingAlert2", "staging")}
+		fetcher.fetchErrors = map[string]error{"prod": errors.New("connection refused")}
+		cache.refreshAlerts()
+
+		if _, ok := cache.GetAlert(stagingFingerprint); ok {
+			t.Error("staging alert should resolve when its healthy source no longer reports it")
+		}
+		if _, ok := cache.GetAlert(prodFingerprint); !ok {
+			t.Error("prod alert must survive while its source is still failing")
+		}
+	})
+
+	t.Run("All sources failing leaves the cache untouched", func(t *testing.T) {
+		fetcher.alerts = nil
+		fetcher.fetchErrors = map[string]error{
+			"prod":    errors.New("connection refused"),
+			"staging": errors.New("connection refused"),
+		}
+		cache.refreshAlerts()
+
+		if _, ok := cache.GetAlert(prodFingerprint); !ok {
+			t.Error("prod alert must survive a total fetch failure")
+		}
+	})
+
+	t.Run("Recovered source reconciles again", func(t *testing.T) {
+		// prod comes back with no alerts: its cached alert now genuinely resolved.
+		fetcher.alerts = []alertmanager.AlertWithSource{}
+		fetcher.fetchErrors = nil
+		cache.refreshAlerts()
+
+		if _, ok := cache.GetAlert(prodFingerprint); ok {
+			t.Error("prod alert should resolve once its source answers without it")
 		}
 	})
 }


### PR DESCRIPTION
## Problem

A single failed poll of one Alertmanager (restart, network blip, 503) made `MultiClient.FetchAllAlerts` return a partial result with `err == nil`. `AlertCache.refreshAlerts` then treated every alert of the unreachable source as resolved: bogus `resolved_alerts` rows, poisoned MTTR/MTTA statistics, an SSE disappear/reappear storm, and thousands of concurrent gRPC calls from unbounded `go` statements.

## Changes

- **`internal/alertmanager/client.go`** — new `MultiClient.FetchAllAlertsDetailed()` returns `([]AlertWithSource, map[string]error)` so callers can tell a partial fetch from a genuinely empty one. `FetchAllAlerts` is now a thin wrapper with its previous contract (error only when every source failed and nothing was fetched), so `FetchAllActiveAlerts` and the handlers are unchanged.
- **`internal/webui/services/alert_cache.go`** —
  - `refreshAlerts` uses the detailed fetch: the resolve pass skips any cached alert whose `Source` is in the failed map, so an unreachable Alertmanager's alerts stay in the cache, are not archived, and are not removed from the SSE stream. Each failed source is logged.
  - When nothing was fetched and at least one source errored, the cycle returns early — the previous total-failure behaviour (cache untouched).
  - The fired/resolved/archive backend calls now run through `runBounded`, a fixed 8-slot semaphore, so a large diff can no longer open thousands of concurrent gRPC calls.
  - The cache holds the fetcher behind a small `alertFetcher` interface (with a typed-nil guard in `NewAlertCache`) to keep the refresh cycle testable.
- **`internal/webui/services/alert_cache_test.go`** — `TestAlertCache_RefreshWithPartialFetchFailure` drives full refresh cycles through a fake fetcher: failed-source alerts survive unresolved, healthy-source alerts still reconcile (including resolution), total failure leaves the cache untouched, and a recovered source resolves normally again.

## Validation

- `go build ./...`, `go vet` on the touched packages: clean (the `router.go:52` `%w` vet warning is pre-existing on `main`).
- `go test ./...`: 38 tests pass.

## Notes

- A single Alertmanager answering 200 with an empty list (restart before state repopulation) is indistinguishable from "everything resolved" without deeper heartbeat logic; behaviour there is unchanged, per the acceptance criteria.

Closes #45

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>