### PR TITLE
fix: reclaim session-scoped state (expired sessions, per-session caches)

### DIFF
--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -66,6 +66,7 @@ func (s *Server) Start() error {
 
 	s.startResolvedAlertCleanup()
 	s.startStatisticsCleanup()
+	s.startSessionCleanup()
 
 	shutdownChan := make(chan struct{})
 	s.setupGracefulShutdown(shutdownChan)
@@ -390,6 +391,43 @@ func (s *Server) performStatisticsCleanup() {
 	} else {
 		log.Printf("✅ No old alert statistics to clean up")
 	}
+}
+
+// startSessionCleanup starts a background job to remove expired sessions
+func (s *Server) startSessionCleanup() {
+	log.Println("🧹 Starting expired session cleanup job (runs every hour)")
+
+	go func() {
+		s.performSessionCleanup()
+
+		ticker := time.NewTicker(1 * time.Hour)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				s.performSessionCleanup()
+			case <-s.cleanupDone:
+				log.Println("🛑 Stopping expired session cleanup job")
+				return
+			}
+		}
+	}()
+}
+
+// performSessionCleanup removes sessions whose expires_at is in the past
+func (s *Server) performSessionCleanup() {
+	if s.db == nil {
+		log.Println("⚠️  Database not initialized, skipping session cleanup")
+		return
+	}
+
+	if err := s.db.CleanupExpiredSessions(); err != nil {
+		log.Printf("❌ Error during expired session cleanup: %v", err)
+		return
+	}
+
+	log.Println("✅ Expired sessions cleaned up")
 }
 
 func (s *Server) healthCheckHandler(w http.ResponseWriter, r *http.Request) {

--- a/internal/webui/handlers/handlers.go
+++ b/internal/webui/handlers/handlers.go
@@ -216,11 +216,25 @@ func Register(c *gin.Context) {
 	}))
 }
 
+// purgeSessionCaches drops all in-memory state keyed by the session ID
+func purgeSessionCaches(sessionID string) {
+	if sessionID == "" {
+		return
+	}
+	if colorService != nil {
+		colorService.InvalidateUserCache(sessionID)
+	}
+	if hiddenAlertsService != nil {
+		hiddenAlertsService.InvalidateCache(sessionID)
+	}
+}
+
 func Logout(c *gin.Context) {
 	sessionID := middleware.GetSessionID(c)
 	if sessionID != "" {
 		backendClient.Logout(sessionID)
 	}
+	purgeSessionCaches(sessionID)
 
 	err := middleware.ClearSession(c)
 	if err != nil {

--- a/internal/webui/handlers/oauth_handlers.go
+++ b/internal/webui/handlers/oauth_handlers.go
@@ -202,6 +202,7 @@ func OAuthLogout(c *gin.Context) {
 	if sessionID != "" && backendClient != nil {
 		backendClient.Logout(sessionID)
 	}
+	purgeSessionCaches(sessionID)
 
 	if userIDStr, ok := userID.(string); ok && userIDStr != "" {
 		logOAuthActivity(&userIDStr, provider, "logout", true, "", getClientIP(c), c.GetHeader("User-Agent"))

--- a/internal/webui/services/color_service.go
+++ b/internal/webui/services/color_service.go
@@ -123,6 +123,10 @@ func (cs *ColorService) getUserColorCache(sessionID string) (*ColorPreferenceCac
 		return cache, nil
 	}
 
+	// ponytail: opportunistic sweep instead of a janitor goroutine — expired
+	// entries for idle sessions are dropped whenever any entry is refreshed.
+	cs.sweepExpiredLocked()
+
 	preferences, err := cs.backendClient.GetUserColorPreferences(sessionID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get user color preferences: %w", err)
@@ -155,6 +159,15 @@ func (cs *ColorService) getUserColorCache(sessionID string) (*ColorPreferenceCac
 
 	cs.colorCache[sessionID] = cache
 	return cache, nil
+}
+
+// sweepExpiredLocked deletes all expired cache entries. Caller must hold cacheMutex.
+func (cs *ColorService) sweepExpiredLocked() {
+	for sessionID, cache := range cs.colorCache {
+		if time.Since(cache.CachedAt) >= cache.TTL {
+			delete(cs.colorCache, sessionID)
+		}
+	}
 }
 
 func (cs *ColorService) buildLookupMap(preferences []webuimodels.UserColorPreference) map[string]*ColorMatch {

--- a/internal/webui/services/hidden_alerts_service.go
+++ b/internal/webui/services/hidden_alerts_service.go
@@ -5,12 +5,17 @@ import (
 	"log"
 	"regexp"
 	"sync"
+	"time"
 
 	"notificator/internal/backend/models"
 	alertpb "notificator/internal/backend/proto/alert"
 	"notificator/internal/webui/client"
 	webuimodels "notificator/internal/webui/models"
 )
+
+// sessionIdleTTL matches the backend session TTL: cache entries for sessions
+// idle longer than this are unreachable (session expired) and can be dropped.
+const sessionIdleTTL = 7 * 24 * time.Hour
 
 // HiddenAlertsService manages hidden alerts and rules for users
 type HiddenAlertsService struct {
@@ -19,6 +24,7 @@ type HiddenAlertsService struct {
 	userHiddenAlerts    map[string]map[string]bool             // userID -> fingerprint -> hidden
 	userHiddenRules     map[string][]models.UserHiddenRule     // userID -> rules
 	compiledRegexRules  map[string]map[string]*regexp.Regexp   // userID -> ruleID -> compiled regex
+	lastAccess          map[string]time.Time                   // userID -> last LoadUserData call
 }
 
 // NewHiddenAlertsService creates a new hidden alerts service
@@ -28,6 +34,7 @@ func NewHiddenAlertsService(backendClient *client.BackendClient) *HiddenAlertsSe
 		userHiddenAlerts:   make(map[string]map[string]bool),
 		userHiddenRules:    make(map[string][]models.UserHiddenRule),
 		compiledRegexRules: make(map[string]map[string]*regexp.Regexp),
+		lastAccess:         make(map[string]time.Time),
 	}
 	
 	// Load initial data
@@ -84,35 +91,49 @@ func (s *HiddenAlertsService) LoadUserData(sessionID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Initialize maps if needed
-	if s.userHiddenAlerts[sessionID] == nil {
+	// Replace cached hidden alerts wholesale so entries removed in the backend
+	// (or stale regexes for deleted rules) do not accumulate.
+	if hiddenAlertsErr == nil {
+		freshAlerts := make(map[string]bool, len(hiddenAlerts))
+		for _, alert := range hiddenAlerts {
+			freshAlerts[alert.Fingerprint] = true
+		}
+		s.userHiddenAlerts[sessionID] = freshAlerts
+	} else if s.userHiddenAlerts[sessionID] == nil {
 		s.userHiddenAlerts[sessionID] = make(map[string]bool)
 	}
 
-	if s.userHiddenRules[sessionID] == nil {
-		s.userHiddenRules[sessionID] = []models.UserHiddenRule{}
-	}
-
-	if s.compiledRegexRules[sessionID] == nil {
-		s.compiledRegexRules[sessionID] = make(map[string]*regexp.Regexp)
-	}
-
-	// Populate cache with hidden alerts
-	if hiddenAlertsErr == nil {
-		for _, alert := range hiddenAlerts {
-			s.userHiddenAlerts[sessionID][alert.Fingerprint] = true
-		}
-	}
-
-	// Populate cache with rules and compiled regexes
 	if hiddenRulesErr == nil {
 		s.userHiddenRules[sessionID] = rules
-		for id, regex := range compiledRegexes {
-			s.compiledRegexRules[sessionID][id] = regex
+		s.compiledRegexRules[sessionID] = compiledRegexes
+	} else {
+		if s.userHiddenRules[sessionID] == nil {
+			s.userHiddenRules[sessionID] = []models.UserHiddenRule{}
+		}
+		if s.compiledRegexRules[sessionID] == nil {
+			s.compiledRegexRules[sessionID] = make(map[string]*regexp.Regexp)
 		}
 	}
 
+	s.lastAccess[sessionID] = time.Now()
+	// ponytail: opportunistic sweep instead of a janitor goroutine — sessions
+	// idle past the backend session TTL are dropped on the next load by anyone.
+	s.sweepIdleSessionsLocked()
+
 	return nil
+}
+
+// sweepIdleSessionsLocked drops cache entries for sessions with no LoadUserData
+// call within sessionIdleTTL. Caller must hold s.mu.
+func (s *HiddenAlertsService) sweepIdleSessionsLocked() {
+	for sessionID, last := range s.lastAccess {
+		if time.Since(last) >= sessionIdleTTL {
+			delete(s.userHiddenAlerts, sessionID)
+			delete(s.userHiddenRules, sessionID)
+			delete(s.compiledRegexRules, sessionID)
+			delete(s.lastAccess, sessionID)
+		}
+	}
 }
 
 // IsAlertHidden checks if an alert is hidden for a user using sessionID
@@ -355,6 +376,7 @@ func (s *HiddenAlertsService) InvalidateCache(sessionID string) {
 	delete(s.userHiddenAlerts, sessionID)
 	delete(s.userHiddenRules, sessionID)
 	delete(s.compiledRegexRules, sessionID)
+	delete(s.lastAccess, sessionID)
 }
 
 // GetUserHiddenRules gets all hidden rules for a user

--- a/internal/webui/services/session_cache_cleanup_test.go
+++ b/internal/webui/services/session_cache_cleanup_test.go
@@ -1,0 +1,73 @@
+package services
+
+import (
+	"regexp"
+	"testing"
+	"time"
+
+	"notificator/internal/backend/models"
+)
+
+func TestColorServiceSweepExpired(t *testing.T) {
+	cs := NewColorService(nil)
+	cs.colorCache["stale"] = &ColorPreferenceCache{CachedAt: time.Now().Add(-10 * time.Minute), TTL: cs.cacheTTL}
+	cs.colorCache["fresh"] = &ColorPreferenceCache{CachedAt: time.Now(), TTL: cs.cacheTTL}
+
+	cs.cacheMutex.Lock()
+	cs.sweepExpiredLocked()
+	cs.cacheMutex.Unlock()
+
+	if _, ok := cs.colorCache["stale"]; ok {
+		t.Error("expired entry should have been swept")
+	}
+	if _, ok := cs.colorCache["fresh"]; !ok {
+		t.Error("fresh entry should have been kept")
+	}
+}
+
+func TestHiddenAlertsServiceSweepIdleSessions(t *testing.T) {
+	s := NewHiddenAlertsService(nil)
+	for session, last := range map[string]time.Time{
+		"idle":   time.Now().Add(-sessionIdleTTL - time.Hour),
+		"active": time.Now(),
+	} {
+		s.userHiddenAlerts[session] = map[string]bool{"fp": true}
+		s.userHiddenRules[session] = []models.UserHiddenRule{{ID: "r1"}}
+		s.compiledRegexRules[session] = map[string]*regexp.Regexp{"r1": regexp.MustCompile("x")}
+		s.lastAccess[session] = last
+	}
+
+	s.mu.Lock()
+	s.sweepIdleSessionsLocked()
+	s.mu.Unlock()
+
+	if _, ok := s.userHiddenAlerts["idle"]; ok {
+		t.Error("idle session should have been swept from userHiddenAlerts")
+	}
+	if _, ok := s.userHiddenRules["idle"]; ok {
+		t.Error("idle session should have been swept from userHiddenRules")
+	}
+	if _, ok := s.compiledRegexRules["idle"]; ok {
+		t.Error("idle session should have been swept from compiledRegexRules")
+	}
+	if _, ok := s.lastAccess["idle"]; ok {
+		t.Error("idle session should have been swept from lastAccess")
+	}
+	if _, ok := s.userHiddenAlerts["active"]; !ok {
+		t.Error("active session should have been kept")
+	}
+}
+
+func TestHiddenAlertsServiceInvalidateCacheRemovesAllMaps(t *testing.T) {
+	s := NewHiddenAlertsService(nil)
+	s.userHiddenAlerts["sess"] = map[string]bool{"fp": true}
+	s.userHiddenRules["sess"] = []models.UserHiddenRule{{ID: "r1"}}
+	s.compiledRegexRules["sess"] = map[string]*regexp.Regexp{"r1": regexp.MustCompile("x")}
+	s.lastAccess["sess"] = time.Now()
+
+	s.InvalidateCache("sess")
+
+	if len(s.userHiddenAlerts)+len(s.userHiddenRules)+len(s.compiledRegexRules)+len(s.lastAccess) != 0 {
+		t.Error("InvalidateCache should remove the session from all maps")
+	}
+}


### PR DESCRIPTION
## Summary

Session-scoped state was created on every login and never reclaimed (#55): expired rows piled up in the `sessions` table, and the WebUI's per-session in-memory caches (`ColorService.colorCache`, `HiddenAlertsService` maps) grew for the lifetime of the process.

## Changes

**Backend**
- `internal/backend/server.go`: new `startSessionCleanup` runs `CleanupExpiredSessions` (previously dead code with zero callers) immediately and then hourly, following the existing `startStatisticsCleanup` pattern. It listens on the shared `cleanupDone` channel, so the goroutine exits on graceful shutdown.

**WebUI — logout purge**
- `Logout` and `OAuthLogout` now call a shared `purgeSessionCaches` helper that drops the session's entry from `ColorService` and all `HiddenAlertsService` maps, so a login/logout loop leaves cache sizes unchanged.

**WebUI — eviction for sessions that never log out**
- `ColorService`: expired entries (past the 5-minute TTL) are swept opportunistically whenever any entry is refreshed under the write lock — no janitor goroutine needed.
- `HiddenAlertsService`: tracks last access per session and sweeps sessions idle past the 7-day backend session TTL on the next `LoadUserData` call.
- `LoadUserData` now replaces cached hidden alerts, rules, and compiled regexes wholesale instead of merging additively, so fingerprints and regexes for entries deleted in the backend no longer accumulate (the `compiledRegexRules` leak called out in the issue).

## Validation

- `go build ./...` passes
- `go test ./internal/webui/services/ ./internal/backend/...` — 41 tests pass, including new tests covering both sweeps and the full-map purge in `InvalidateCache`

Closes #55

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>