### PR TITLE
perf(backend): bound GetAllAcknowledgedAlerts to live alert keys

### DIFF
--- a/internal/backend/database/gorm_db.go
+++ b/internal/backend/database/gorm_db.go
@@ -474,20 +474,34 @@ func (gdb *GormDB) DeleteAcknowledgment(alertKey, userID string) error {
 	return nil
 }
 
-func (gdb *GormDB) GetAllAcknowledgedAlerts() (map[string]models.AcknowledgmentWithUser, error) {
+// GetAllAcknowledgedAlerts retrieves the latest acknowledgment for each of the
+// given alert keys in a single query, mirroring GetCommentCountsBatch so the
+// scan is bounded by the number of live alerts instead of the whole table.
+func (gdb *GormDB) GetAllAcknowledgedAlerts(alertKeys []string) (map[string]models.AcknowledgmentWithUser, error) {
+	result := make(map[string]models.AcknowledgmentWithUser)
+
+	if len(alertKeys) == 0 {
+		return result, nil
+	}
+
 	var acks []models.AcknowledgmentWithUser
+
+	latest := gdb.db.Table("acknowledgments").
+		Select("alert_key, MAX(created_at) as max_created").
+		Where("alert_key IN ?", alertKeys).
+		Group("alert_key")
 
 	err := gdb.db.Table("acknowledgments").
 		Select("acknowledgments.*, users.username").
 		Joins("JOIN users ON users.id = acknowledgments.user_id").
-		Joins("JOIN (SELECT alert_key, MAX(created_at) as max_created FROM acknowledgments GROUP BY alert_key) latest ON acknowledgments.alert_key = latest.alert_key AND acknowledgments.created_at = latest.max_created").
+		Joins("JOIN (?) latest ON acknowledgments.alert_key = latest.alert_key AND acknowledgments.created_at = latest.max_created", latest).
+		Where("acknowledgments.alert_key IN ?", alertKeys).
 		Find(&acks).Error
 
 	if err != nil {
 		return nil, err
 	}
 
-	result := make(map[string]models.AcknowledgmentWithUser)
 	for _, ack := range acks {
 		result[ack.AlertKey] = ack
 	}

--- a/internal/backend/database/gorm_db_test.go
+++ b/internal/backend/database/gorm_db_test.go
@@ -1,0 +1,81 @@
+package database
+
+import (
+	"testing"
+	"time"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"notificator/internal/backend/models"
+)
+
+func newTestDB(t *testing.T) *GormDB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file::memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&models.User{}, &models.Acknowledgment{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return &GormDB{db: db, dbType: "sqlite"}
+}
+
+func TestGetAllAcknowledgedAlerts(t *testing.T) {
+	gdb := newTestDB(t)
+
+	alice := models.User{ID: "u1", Username: "alice", Email: "alice@example.com"}
+	bob := models.User{ID: "u2", Username: "bob", Email: "bob@example.com"}
+	if err := gdb.db.Create([]*models.User{&alice, &bob}).Error; err != nil {
+		t.Fatalf("create users: %v", err)
+	}
+
+	base := time.Now().UTC().Truncate(time.Second)
+	acks := []models.Acknowledgment{
+		{ID: "a1", AlertKey: "key-a", UserID: alice.ID, Reason: "old", CreatedAt: base.Add(-time.Hour)},
+		{ID: "a2", AlertKey: "key-a", UserID: bob.ID, Reason: "latest", CreatedAt: base},
+		{ID: "b1", AlertKey: "key-b", UserID: alice.ID, Reason: "only", CreatedAt: base},
+		{ID: "c1", AlertKey: "key-not-cached", UserID: alice.ID, Reason: "stale", CreatedAt: base},
+	}
+	for i := range acks {
+		if err := gdb.db.Create(&acks[i]).Error; err != nil {
+			t.Fatalf("create ack: %v", err)
+		}
+	}
+
+	result, err := gdb.GetAllAcknowledgedAlerts([]string{"key-a", "key-b", "key-missing"})
+	if err != nil {
+		t.Fatalf("GetAllAcknowledgedAlerts: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected 2 acks, got %d: %v", len(result), result)
+	}
+	if got := result["key-a"]; got.Reason != "latest" || got.Username != "bob" {
+		t.Errorf("key-a: expected latest ack by bob, got reason=%q user=%q", got.Reason, got.Username)
+	}
+	if got := result["key-b"]; got.Reason != "only" || got.Username != "alice" {
+		t.Errorf("key-b: expected ack by alice, got reason=%q user=%q", got.Reason, got.Username)
+	}
+	if _, ok := result["key-not-cached"]; ok {
+		t.Errorf("key-not-cached must not be returned when not requested")
+	}
+
+	empty, err := gdb.GetAllAcknowledgedAlerts(nil)
+	if err != nil {
+		t.Fatalf("empty keys: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("expected no acks for empty key list, got %v", empty)
+	}
+}
+
+func TestAcknowledgmentCompositeIndexExists(t *testing.T) {
+	gdb := newTestDB(t)
+	if !gdb.db.Migrator().HasIndex(&models.Acknowledgment{}, "idx_acknowledgments_alert_key_created_at") {
+		t.Fatal("composite index idx_acknowledgments_alert_key_created_at missing after migration")
+	}
+}

--- a/internal/backend/models/models.go
+++ b/internal/backend/models/models.go
@@ -91,10 +91,10 @@ func (c *Comment) BeforeCreate(tx *gorm.DB) error {
 
 type Acknowledgment struct {
 	ID        string    `gorm:"primaryKey;type:varchar(32)" json:"id"`
-	AlertKey  string    `gorm:"not null;size:500;index" json:"alert_key"`
+	AlertKey  string    `gorm:"not null;size:500;index;index:idx_acknowledgments_alert_key_created_at,priority:1" json:"alert_key"`
 	UserID    string    `gorm:"not null;size:32" json:"user_id"`
 	Reason    string    `gorm:"not null;type:text" json:"reason"`
-	CreatedAt time.Time `json:"created_at"`
+	CreatedAt time.Time `gorm:"index:idx_acknowledgments_alert_key_created_at,priority:2" json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 
 	User User `gorm:"foreignKey:UserID" json:"user,omitempty"`

--- a/internal/backend/proto/alert/alert.pb.go
+++ b/internal/backend/proto/alert/alert.pb.go
@@ -841,6 +841,7 @@ func (x *GetAcknowledgmentsResponse) GetCount() int32 {
 
 type GetAllAcknowledgedAlertsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
+	AlertKeys     []string               `protobuf:"bytes,1,rep,name=alert_keys,json=alertKeys,proto3" json:"alert_keys,omitempty"` // Only return acknowledgments for these alert keys
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -873,6 +874,13 @@ func (x *GetAllAcknowledgedAlertsRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use GetAllAcknowledgedAlertsRequest.ProtoReflect.Descriptor instead.
 func (*GetAllAcknowledgedAlertsRequest) Descriptor() ([]byte, []int) {
 	return file_proto_alert_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *GetAllAcknowledgedAlertsRequest) GetAlertKeys() []string {
+	if x != nil {
+		return x.AlertKeys
+	}
+	return nil
 }
 
 type GetAllAcknowledgedAlertsResponse struct {
@@ -9940,8 +9948,10 @@ const file_proto_alert_proto_rawDesc = "" +
 	"\talert_key\x18\x01 \x01(\tR\balertKey\"\x7f\n" +
 	"\x1aGetAcknowledgmentsResponse\x12K\n" +
 	"\x0facknowledgments\x18\x01 \x03(\v2!.notificator.alert.AcknowledgmentR\x0facknowledgments\x12\x14\n" +
-	"\x05count\x18\x02 \x01(\x05R\x05count\"!\n" +
-	"\x1fGetAllAcknowledgedAlertsRequest\"\xa0\x02\n" +
+	"\x05count\x18\x02 \x01(\x05R\x05count\"@\n" +
+	"\x1fGetAllAcknowledgedAlertsRequest\x12\x1d\n" +
+	"\n" +
+	"alert_keys\x18\x01 \x03(\tR\talertKeys\"\xa0\x02\n" +
 	" GetAllAcknowledgedAlertsResponse\x12|\n" +
 	"\x13acknowledged_alerts\x18\x01 \x03(\v2K.notificator.alert.GetAllAcknowledgedAlertsResponse.AcknowledgedAlertsEntryR\x12acknowledgedAlerts\x12\x14\n" +
 	"\x05count\x18\x02 \x01(\x05R\x05count\x1ah\n" +

--- a/internal/backend/services/acknowledgment_service.go
+++ b/internal/backend/services/acknowledgment_service.go
@@ -27,6 +27,6 @@ func (s *AcknowledgmentService) DeleteAcknowledgment(ctx context.Context, alertK
 	return s.db.DeleteAcknowledgment(alertKey, userID)
 }
 
-func (s *AcknowledgmentService) GetAllAcknowledgedAlerts(ctx context.Context) (map[string]models.AcknowledgmentWithUser, error) {
-	return s.db.GetAllAcknowledgedAlerts()
+func (s *AcknowledgmentService) GetAllAcknowledgedAlerts(ctx context.Context, alertKeys []string) (map[string]models.AcknowledgmentWithUser, error) {
+	return s.db.GetAllAcknowledgedAlerts(alertKeys)
 }

--- a/internal/backend/services/services.go
+++ b/internal/backend/services/services.go
@@ -662,7 +662,7 @@ func (s *AlertServiceGorm) GetAcknowledgments(ctx context.Context, req *alertpb.
 
 // GetAllAcknowledgedAlerts implements the GetAllAcknowledgedAlerts RPC method
 func (s *AlertServiceGorm) GetAllAcknowledgedAlerts(ctx context.Context, req *alertpb.GetAllAcknowledgedAlertsRequest) (*alertpb.GetAllAcknowledgedAlertsResponse, error) {
-	acknowledgedAlerts, err := s.db.GetAllAcknowledgedAlerts()
+	acknowledgedAlerts, err := s.db.GetAllAcknowledgedAlerts(req.AlertKeys)
 	if err != nil {
 		log.Printf("Error getting all acknowledged alerts: %v", err)
 		return &alertpb.GetAllAcknowledgedAlertsResponse{

--- a/internal/webui/client/backend_client.go
+++ b/internal/webui/client/backend_client.go
@@ -336,8 +336,9 @@ func (c *BackendClient) GetAcknowledgments(alertKey string) ([]*alertpb.Acknowle
 	return resp.Acknowledgments, nil
 }
 
-// GetAllAcknowledgedAlerts retrieves all acknowledged alerts from the backend
-func (c *BackendClient) GetAllAcknowledgedAlerts() (map[string]*alertpb.Acknowledgment, error) {
+// GetAllAcknowledgedAlerts retrieves the latest acknowledgment for each of the
+// given alert keys from the backend
+func (c *BackendClient) GetAllAcknowledgedAlerts(alertKeys []string) (map[string]*alertpb.Acknowledgment, error) {
 	if c.alertClient == nil {
 		return nil, fmt.Errorf("not connected to backend")
 	}
@@ -345,7 +346,7 @@ func (c *BackendClient) GetAllAcknowledgedAlerts() (map[string]*alertpb.Acknowle
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	req := &alertpb.GetAllAcknowledgedAlertsRequest{}
+	req := &alertpb.GetAllAcknowledgedAlertsRequest{AlertKeys: alertKeys}
 
 	resp, err := c.alertClient.GetAllAcknowledgedAlerts(ctx, req)
 	if err != nil {

--- a/internal/webui/services/alert_cache.go
+++ b/internal/webui/services/alert_cache.go
@@ -447,9 +447,24 @@ func (ac *AlertCache) loadBackendData() {
 }
 
 func (ac *AlertCache) loadAcknowledgmentsEfficiently() {
-	log.Printf("Loading all acknowledged alerts from backend...")
+	log.Printf("Loading acknowledgments for cached alerts from backend...")
 
-	acknowledgedAlerts, err := ac.backendClient.GetAllAcknowledgedAlerts()
+	// Step 1: collect fingerprints under RLock (no write needed)
+	ac.mu.RLock()
+	fingerprints := make([]string, 0, len(ac.alerts))
+	for fingerprint := range ac.alerts {
+		fingerprints = append(fingerprints, fingerprint)
+	}
+	ac.mu.RUnlock()
+
+	// Handle empty case without a backend round-trip
+	if len(fingerprints) == 0 {
+		log.Printf("No alerts to load acknowledgments for")
+		return
+	}
+
+	// Step 2: call gRPC with NO lock held
+	acknowledgedAlerts, err := ac.backendClient.GetAllAcknowledgedAlerts(fingerprints)
 	if err != nil {
 		log.Printf("Failed to load acknowledged alerts from backend: %v", err)
 		return

--- a/proto/alert.proto
+++ b/proto/alert.proto
@@ -143,7 +143,7 @@ message GetAcknowledgmentsResponse {
 }
 
 message GetAllAcknowledgedAlertsRequest {
-  // No parameters needed - returns all acknowledged alerts
+  repeated string alert_keys = 1; // Only return acknowledgments for these alert keys
 }
 
 message GetAllAcknowledgedAlertsResponse {


### PR DESCRIPTION
## Problem

Every WebUI alert-cache refresh cycle (default 10 s) called `GetAllAcknowledgedAlerts` with no arguments, which ran a full scan of the `acknowledgments` table plus a self-join over an unbounded `GROUP BY` subquery, then shipped **every acknowledgment ever created** over gRPC — only for the WebUI to keep the handful matching currently-cached fingerprints. The table is never pruned, so cost grew with deployment history rather than with alerts on screen.

## Changes

Mirrors the existing `GetCommentCountsBatch` pattern:

- **`proto/alert.proto`**: added `repeated string alert_keys = 1` to `GetAllAcknowledgedAlertsRequest`; regenerated with `make proto` (no hand edits to `*.pb.go`).
- **`internal/backend/database/gorm_db.go`**: `GetAllAcknowledgedAlerts` now takes the key list and applies `alert_key IN (...)` to both the outer query and the `latest` (max `created_at` per key) subquery, so the scan is bounded by the number of live alerts. Empty input returns immediately with no DB round-trip.
- **`internal/backend/models/models.go`**: composite index `idx_acknowledgments_alert_key_created_at` on `(alert_key, created_at)` so the latest-per-key lookup is index-served; created by the existing `AutoMigrate` path.
- **`internal/webui/services/alert_cache.go`**: `loadAcknowledgmentsEfficiently` collects cached fingerprints under `RLock` first (same three-step shape as `loadCommentCountsEfficiently`) and passes them to the backend; skips the gRPC call entirely when the cache is empty.
- **`internal/backend/services/*.go`, `internal/webui/client/backend_client.go`**: plumb the key list through the RPC service and client.

## Validation

- `go build ./...` and `go test ./...` pass (pre-existing `go vet` warning in `internal/webui/router.go:52` is untouched by this change).
- New `internal/backend/database/gorm_db_test.go` covers: latest-per-key selection with username join, filtering to requested keys only, empty-input early return, and presence of the composite index after migration.

## Acceptance criteria

- A refresh with N cached alerts sends at most N keys and receives at most N acknowledgments; acks for uncached alerts never cross the gRPC boundary.
- Badge behaviour unchanged: ack shown, un-ack clears, another user's ack visible after one cycle (same latest-per-key + username query, just bounded).
- Hot-path SQL bounded by `alert_key IN (...)` on both the outer query and the subquery.
- Composite `(alert_key, created_at)` index exists after migration.
- Empty cache makes no DB round-trip.

Closes #47

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>