### PR TITLE
fix(webui): alert cache hands out live alert pointers — return snapshots, add MutateAlert

### DIFF
--- a/internal/webui/handlers/dashboard_handlers.go
+++ b/internal/webui/handlers/dashboard_handlers.go
@@ -861,12 +861,19 @@ func processAlertAction(c *gin.Context, fingerprint, action, comment, userID str
 			}
 		}
 
-		// Update local cache
-		alert.IsAcknowledged = true
-		alert.AcknowledgedBy = userID
-		alert.AcknowledgedAt = time.Now()
-		// Always increment comment count since we add an acknowledgment comment
-		alert.CommentCount++
+		// Update local cache under the cache lock (GetAlert returns a snapshot).
+		// Mirror the change on the snapshot so the statistics goroutine below
+		// sees the acknowledged state without touching cache-resident memory.
+		ackAt := time.Now()
+		applyAck := func(a *webuimodels.DashboardAlert) {
+			a.IsAcknowledged = true
+			a.AcknowledgedBy = userID
+			a.AcknowledgedAt = ackAt
+			// Always increment comment count since we add an acknowledgment comment
+			a.CommentCount++
+		}
+		alertCache.MutateAlert(fingerprint, applyAck)
+		applyAck(alert)
 
 		// Capture acknowledgment statistics
 		if backendClient != nil && backendClient.IsConnected() {
@@ -897,19 +904,24 @@ func processAlertAction(c *gin.Context, fingerprint, action, comment, userID str
 			}
 		}
 
-		// Update local cache
-		alert.IsAcknowledged = false
-		alert.AcknowledgedBy = ""
-		alert.AcknowledgedAt = time.Time{}
-		// Increment comment count for unacknowledgment comment
-		alert.CommentCount++
+		// Update local cache under the cache lock (GetAlert returns a snapshot)
+		alertCache.MutateAlert(fingerprint, func(a *webuimodels.DashboardAlert) {
+			a.IsAcknowledged = false
+			a.AcknowledgedBy = ""
+			a.AcknowledgedAt = time.Time{}
+			// Increment comment count for unacknowledgment comment
+			a.CommentCount++
+		})
 
 	case "resolve":
 		// Mark alert as resolved (this is more of a UI state than backend)
-		alert.Status.State = "resolved"
-		alert.EndsAt = time.Now()
-		alert.IsResolved = true
-		alert.ResolvedAt = time.Now()
+		resolvedAt := time.Now()
+		alertCache.MutateAlert(fingerprint, func(a *webuimodels.DashboardAlert) {
+			a.Status.State = "resolved"
+			a.EndsAt = resolvedAt
+			a.IsResolved = true
+			a.ResolvedAt = resolvedAt
+		})
 
 		// Add a comment about resolution for audit trail
 		if backendClient != nil && backendClient.IsConnected() {
@@ -924,7 +936,7 @@ func processAlertAction(c *gin.Context, fingerprint, action, comment, userID str
 				fmt.Printf("Warning: failed to add resolution comment: %v\n", err)
 			} else {
 				// Increment comment count if comment was added successfully
-				alert.CommentCount++
+				alertCache.MutateAlert(fingerprint, func(a *webuimodels.DashboardAlert) { a.CommentCount++ })
 			}
 		}
 
@@ -1412,9 +1424,11 @@ func AddAlertComment(c *gin.Context) {
 		return
 	}
 
-	// Update comment count in alert cache
-	alert.CommentCount++
-	alert.LastCommentAt = time.Now()
+	// Update comment count in alert cache (the lookup above returned a snapshot)
+	alertCache.MutateAlert(fingerprint, func(a *webuimodels.DashboardAlert) {
+		a.CommentCount++
+		a.LastCommentAt = time.Now()
+	})
 
 	c.JSON(http.StatusOK, webuimodels.SuccessResponse(gin.H{
 		"message": "Comment added successfully",
@@ -1984,7 +1998,7 @@ func processSilenceAction(c *gin.Context, fingerprint, comment, userID string) e
 			fmt.Printf("Warning: failed to add silence comment: %v\n", err)
 		} else {
 			// Increment comment count in cache only if comment was added successfully
-			alert.CommentCount++
+			alertCache.MutateAlert(fingerprint, func(a *webuimodels.DashboardAlert) { a.CommentCount++ })
 		}
 	}
 

--- a/internal/webui/services/alert_cache.go
+++ b/internal/webui/services/alert_cache.go
@@ -266,9 +266,10 @@ func (ac *AlertCache) refreshAlerts() {
 		}
 	}
 
+	activeCount := len(ac.alerts)
 	ac.mu.Unlock()
 
-	log.Printf("Alert cache refresh complete: %d active alerts, %d newly resolved", len(ac.alerts), resolvedCount)
+	log.Printf("Alert cache refresh complete: %d active alerts, %d newly resolved", activeCount, resolvedCount)
 
 	ac.loadBackendData()
 
@@ -430,6 +431,22 @@ func (ac *AlertCache) UpdateAlert(alert *webuimodels.DashboardAlert) {
 	}
 }
 
+// MutateAlert applies fn to the cached alert under ac.mu; returns false if the
+// fingerprint is not in the live cache. This is the only supported way to write
+// to a cached alert — the read accessors return snapshots, so writes through
+// their return values never reach the cache.
+func (ac *AlertCache) MutateAlert(fingerprint string, fn func(*webuimodels.DashboardAlert)) bool {
+	ac.mu.Lock()
+	defer ac.mu.Unlock()
+
+	alert, exists := ac.alerts[fingerprint]
+	if !exists {
+		return false
+	}
+	fn(alert)
+	return true
+}
+
 func (ac *AlertCache) loadBackendData() {
 	log.Printf("loadBackendData called - checking backend connection...")
 	if ac.backendClient == nil {
@@ -544,9 +561,14 @@ func (ac *AlertCache) GetAllAlerts() []*webuimodels.DashboardAlert {
 	ac.mu.RLock()
 	defer ac.mu.RUnlock()
 
+	// Return snapshots, not cache-resident pointers: the background refresher
+	// keeps mutating the cached structs after this lock is released. A shallow
+	// copy is enough — Labels is never written after construction and
+	// Annotations is only ever replaced wholesale.
 	alerts := make([]*webuimodels.DashboardAlert, 0, len(ac.alerts))
 	for _, alert := range ac.alerts {
-		alerts = append(alerts, alert)
+		alertCopy := *alert
+		alerts = append(alerts, &alertCopy)
 	}
 
 	return alerts
@@ -598,8 +620,11 @@ func (ac *AlertCache) GetAlert(fingerprint string) (*webuimodels.DashboardAlert,
 	ac.mu.RLock()
 
 	if alert, exists := ac.alerts[fingerprint]; exists {
+		// Copy under the lock: the background refresher keeps mutating the
+		// cached struct after RUnlock. Use MutateAlert to write to the cache.
+		alertCopy := *alert
 		ac.mu.RUnlock()
-		return alert, true
+		return &alertCopy, true
 	}
 
 	ac.mu.RUnlock()

--- a/internal/webui/services/alert_cache_test.go
+++ b/internal/webui/services/alert_cache_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -906,4 +907,111 @@ func TestAlertCache_RefreshWithPartialFetchFailure(t *testing.T) {
 			t.Error("prod alert should resolve once its source answers without it")
 		}
 	})
+}
+
+// TestAlertCache_ConcurrentRefreshAndReads runs refresh-style writes (mutations
+// of cached structs under ac.mu) concurrently with the read accessors, exactly
+// like a browser polling the dashboard during the background refresh cycle.
+// It fails under -race when GetAlert/GetAllAlerts hand out cache-resident
+// pointers instead of snapshots.
+func TestAlertCache_ConcurrentRefreshAndReads(t *testing.T) {
+	cache := NewAlertCache(nil, nil, 90, 10*time.Second)
+
+	const fingerprint = "race-fingerprint"
+	cache.UpdateAlert(&webuimodels.DashboardAlert{
+		Fingerprint: fingerprint,
+		Status:      webuimodels.AlertStatus{State: "firing"},
+		Summary:     "race test",
+	})
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Writer: the same field writes loadAcknowledgmentsEfficiently and the
+	// resolve pass perform on cache-resident structs.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			cache.MutateAlert(fingerprint, func(a *webuimodels.DashboardAlert) {
+				a.IsAcknowledged = i%2 == 0
+				a.AcknowledgedBy = "alice"
+				a.Status.State = "resolved"
+				a.CommentCount++
+			})
+		}
+	}()
+
+	// Readers: dereference returned alerts with no lock held, as handlers do.
+	for r := 0; r < 4; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if alert, ok := cache.GetAlert(fingerprint); ok {
+					_ = alert.IsAcknowledged
+					_ = alert.AcknowledgedBy
+					_ = alert.Status.State
+				}
+				for _, alert := range cache.GetAllAlerts() {
+					_ = alert.CommentCount
+					_ = alert.Summary
+				}
+			}
+		}()
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
+
+// TestAlertCache_MutateAlert verifies mutations reach the cache while snapshots
+// returned by the accessors stay isolated from it.
+func TestAlertCache_MutateAlert(t *testing.T) {
+	cache := NewAlertCache(nil, nil, 90, 10*time.Second)
+
+	const fingerprint = "mutate-fingerprint"
+	cache.UpdateAlert(&webuimodels.DashboardAlert{
+		Fingerprint: fingerprint,
+		Status:      webuimodels.AlertStatus{State: "firing"},
+	})
+
+	if cache.MutateAlert("missing", func(a *webuimodels.DashboardAlert) {}) {
+		t.Error("MutateAlert should return false for an unknown fingerprint")
+	}
+
+	ok := cache.MutateAlert(fingerprint, func(a *webuimodels.DashboardAlert) {
+		a.Status.State = "resolved"
+		a.IsResolved = true
+		a.CommentCount++
+	})
+	if !ok {
+		t.Fatal("MutateAlert should return true for a cached fingerprint")
+	}
+
+	cached, exists := cache.GetAlert(fingerprint)
+	if !exists {
+		t.Fatal("alert should still be cached")
+	}
+	if cached.Status.State != "resolved" || !cached.IsResolved || cached.CommentCount != 1 {
+		t.Errorf("mutation not visible on immediate read: %+v", cached)
+	}
+
+	// Writing through a returned snapshot must not touch the cache.
+	cached.CommentCount = 99
+	again, _ := cache.GetAlert(fingerprint)
+	if again.CommentCount != 1 {
+		t.Errorf("accessor returned a cache-resident pointer: CommentCount = %d, want 1", again.CommentCount)
+	}
 }


### PR DESCRIPTION
## Problem

`AlertCache` protected the map with `ac.mu` but returned raw pointers to the cached alert structs. The 10s background refresh (`updateExistingAlert`, `loadAcknowledgmentsEfficiently`, `loadCommentCountsEfficiently`, the resolve pass) kept mutating those structs after readers had released the lock — unsynchronized concurrent read/writes that the race detector flags, serving torn alert rows (e.g. `IsAcknowledged=true` with empty `AcknowledgedBy`). `refreshAlerts` also read `len(ac.alerts)` after `Unlock()`, a candidate for an unrecoverable `fatal error: concurrent map read and map write`.

## Changes

**Read path — snapshots**
- `GetAllAlerts` and `GetAlert` copy each struct under the lock and return the copies; `GetAlertByFingerprint` inherits this. Shallow copy is sufficient: `Labels` is never written after construction and `Annotations` is only replaced wholesale.
- `refreshAlerts` computes the active-alert count before `Unlock()`.

**Write path — `MutateAlert`**
- New `MutateAlert(fingerprint, fn)` applies `fn` to the cached alert under `ac.mu`; returns `false` if absent.
- `processAlertAction` no longer writes through returned pointers: acknowledge, unacknowledge and resolve go through `MutateAlert`, so each is observable on an immediately following read (resolve still sets `Status.State = "resolved"` / `IsResolved` with no refresh-cycle dependency).
- Two additional write-through sites beyond the issue's list got the same treatment: `AddAlertComment` (`CommentCount`/`LastCommentAt`) and the silence-comment count bump in `processSilenceAction`.
- The acknowledge statistics goroutine receives the handler-local snapshot instead of cache memory.

Dashboard JSON output is unchanged — same fields, same values, only copies instead of shared memory.

## Validation

- New `TestAlertCache_ConcurrentRefreshAndReads` runs refresh-style writes concurrently with `GetAlert`/`GetAllAlerts` readers: verified it **fails with `DATA RACE` on the old accessors** and passes after the fix.
- New `TestAlertCache_MutateAlert` checks mutation visibility on immediate read and that writing through a returned snapshot does not touch the cache.
- `go test -race ./...` — 48 packages green.

Closes #54

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>