### PR TITLE
fix(webui): move color cache RPC out of the process-wide lock

### DIFF
--- a/internal/webui/services/color_service.go
+++ b/internal/webui/services/color_service.go
@@ -8,13 +8,25 @@ import (
 	"sync"
 	"time"
 
+	alertpb "notificator/internal/backend/proto/alert"
 	"notificator/internal/models"
 	"notificator/internal/webui/client"
 	webuimodels "notificator/internal/webui/models"
 )
 
+// colorPreferencesFetcher is the slice of *client.BackendClient the color
+// cache needs; it exists so tests can stub the backend RPC.
+type colorPreferencesFetcher interface {
+	GetUserColorPreferences(sessionID string, impersonateUserID ...string) ([]*alertpb.UserColorPreference, error)
+}
+
+// colorFetchErrTTL is the negative-cache window: after a failed backend
+// fetch, callers get the cached error (and degrade to severity colors)
+// instead of paying the RPC timeout on every request.
+const colorFetchErrTTL = 15 * time.Second
+
 type ColorService struct {
-	backendClient *client.BackendClient
+	backendClient colorPreferencesFetcher
 	colorCache    map[string]*ColorPreferenceCache // userID -> cache
 	cacheMutex    sync.RWMutex
 	defaultColors map[string]string
@@ -27,6 +39,7 @@ type ColorPreferenceCache struct {
 	LookupMap   map[string]*ColorMatch            `json:"-"` // Pre-computed lookups for performance
 	CachedAt    time.Time                         `json:"cachedAt"`
 	TTL         time.Duration                     `json:"ttl"`
+	FetchErr    error                             `json:"-"` // non-nil marks a negative-cache entry
 }
 
 type ColorMatch struct {
@@ -113,23 +126,44 @@ func (cs *ColorService) getUserColorCache(sessionID string) (*ColorPreferenceCac
 	cs.cacheMutex.RUnlock()
 
 	if exists && time.Since(cache.CachedAt) < cache.TTL {
+		if cache.FetchErr != nil {
+			return nil, cache.FetchErr
+		}
 		return cache, nil
 	}
+
+	// Fetch with NO lock held (issue #53): holding the write lock across this
+	// RPC (10s timeout) would stall every dashboard request in the process.
+	// Concurrent misses for the same session fetch in parallel; last store wins.
+	preferences, fetchErr := cs.backendClient.GetUserColorPreferences(sessionID)
 
 	cs.cacheMutex.Lock()
 	defer cs.cacheMutex.Unlock()
 
-	if cache, exists := cs.colorCache[sessionID]; exists && time.Since(cache.CachedAt) < cache.TTL {
-		return cache, nil
+	// Re-check: a concurrent caller may have stored a result while we fetched.
+	if existing, ok := cs.colorCache[sessionID]; ok && time.Since(existing.CachedAt) < existing.TTL {
+		if existing.FetchErr == nil {
+			return existing, nil
+		}
+		if fetchErr != nil {
+			return nil, existing.FetchErr
+		}
+		// Our fetch succeeded; overwrite the failure marker below.
 	}
 
 	// ponytail: opportunistic sweep instead of a janitor goroutine — expired
 	// entries for idle sessions are dropped whenever any entry is refreshed.
 	cs.sweepExpiredLocked()
 
-	preferences, err := cs.backendClient.GetUserColorPreferences(sessionID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get user color preferences: %w", err)
+	if fetchErr != nil {
+		err := fmt.Errorf("failed to get user color preferences: %w", fetchErr)
+		cs.colorCache[sessionID] = &ColorPreferenceCache{
+			UserID:   sessionID,
+			CachedAt: time.Now(),
+			TTL:      colorFetchErrTTL,
+			FetchErr: err,
+		}
+		return nil, err
 	}
 
 	var webuiPrefs []webuimodels.UserColorPreference

--- a/internal/webui/services/color_service_test.go
+++ b/internal/webui/services/color_service_test.go
@@ -1,0 +1,168 @@
+package services
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	alertpb "notificator/internal/backend/proto/alert"
+	"notificator/internal/models"
+)
+
+type stubColorFetcher struct {
+	mu      sync.Mutex
+	calls   int
+	delay   time.Duration
+	err     error
+	inFetch chan string   // if set, receives sessionID when a fetch starts
+	release chan struct{} // if set, fetch blocks until closed
+}
+
+func (s *stubColorFetcher) GetUserColorPreferences(sessionID string, _ ...string) ([]*alertpb.UserColorPreference, error) {
+	s.mu.Lock()
+	s.calls++
+	s.mu.Unlock()
+	if s.inFetch != nil {
+		s.inFetch <- sessionID
+	}
+	if s.release != nil {
+		<-s.release
+	}
+	if s.delay > 0 {
+		time.Sleep(s.delay)
+	}
+	return nil, s.err
+}
+
+func (s *stubColorFetcher) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+func newTestColorService(fetcher colorPreferencesFetcher) *ColorService {
+	cs := NewColorService(nil)
+	cs.backendClient = fetcher
+	return cs
+}
+
+// Distinct cold sessions must fetch in parallel, not serialize behind the
+// process-wide lock: 10 concurrent 200ms fetches ≈ 200ms, not 2s.
+func TestColorCacheConcurrentMissesRunInParallel(t *testing.T) {
+	stub := &stubColorFetcher{delay: 200 * time.Millisecond}
+	cs := newTestColorService(stub)
+
+	start := time.Now()
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if _, err := cs.getUserColorCache(fmt.Sprintf("session-%d", i)); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if elapsed := time.Since(start); elapsed > 1*time.Second {
+		t.Fatalf("10 concurrent misses took %v; fetches are serialized", elapsed)
+	}
+	if got := stub.callCount(); got != 10 {
+		t.Fatalf("expected 10 backend calls, got %d", got)
+	}
+}
+
+// A session with a fresh cache entry must not block behind another session's
+// in-flight fetch.
+func TestColorCacheFreshEntryNotBlockedByColdFetch(t *testing.T) {
+	stub := &stubColorFetcher{
+		inFetch: make(chan string, 1),
+		release: make(chan struct{}),
+	}
+	cs := newTestColorService(stub)
+	cs.colorCache["fresh"] = &ColorPreferenceCache{
+		UserID:   "fresh",
+		CachedAt: time.Now(),
+		TTL:      cs.cacheTTL,
+	}
+
+	go cs.getUserColorCache("cold")
+	<-stub.inFetch // cold fetch is now in flight, lock must not be held
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if _, err := cs.getUserColorCache("fresh"); err != nil {
+			t.Errorf("fresh entry returned error: %v", err)
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("fresh session blocked behind another session's fetch")
+	}
+	close(stub.release)
+}
+
+// Failed fetches are negative-cached for 15s: repeated calls within the
+// window hit the backend exactly once.
+func TestColorCacheNegativeCaching(t *testing.T) {
+	stub := &stubColorFetcher{err: errors.New("backend down")}
+	cs := newTestColorService(stub)
+
+	for i := 0; i < 5; i++ {
+		if _, err := cs.getUserColorCache("user"); err == nil {
+			t.Fatal("expected error")
+		}
+	}
+	if got := stub.callCount(); got != 1 {
+		t.Fatalf("expected 1 backend call within negative-cache window, got %d", got)
+	}
+
+	// Age the failure marker past the 15s window instead of sleeping.
+	cs.cacheMutex.Lock()
+	cs.colorCache["user"].CachedAt = time.Now().Add(-colorFetchErrTTL - time.Second)
+	cs.cacheMutex.Unlock()
+
+	if _, err := cs.getUserColorCache("user"); err == nil {
+		t.Fatal("expected error")
+	}
+	if got := stub.callCount(); got != 2 {
+		t.Fatalf("expected 2 backend calls after window expiry, got %d", got)
+	}
+}
+
+// InvalidateUserCache clears a cached failure so the next call retries.
+func TestInvalidateUserCacheClearsNegativeEntry(t *testing.T) {
+	stub := &stubColorFetcher{err: errors.New("backend down")}
+	cs := newTestColorService(stub)
+
+	cs.getUserColorCache("user")
+	cs.getUserColorCache("user")
+	if got := stub.callCount(); got != 1 {
+		t.Fatalf("expected 1 backend call, got %d", got)
+	}
+
+	cs.InvalidateUserCache("user")
+
+	cs.getUserColorCache("user")
+	if got := stub.callCount(); got != 2 {
+		t.Fatalf("expected fresh RPC after invalidation, got %d calls", got)
+	}
+}
+
+// On error, callers still degrade to default severity colors.
+func TestGetAlertColorsFallsBackOnError(t *testing.T) {
+	stub := &stubColorFetcher{err: errors.New("backend down")}
+	cs := newTestColorService(stub)
+
+	alert := &models.Alert{Labels: map[string]string{"severity": "critical"}}
+	result := cs.GetAlertColors(alert, "user")
+	if result == nil || result.ColorSource != "severity" {
+		t.Fatalf("expected severity fallback colors, got %+v", result)
+	}
+}


### PR DESCRIPTION
## Problem

`ColorService.getUserColorCache` took the process-wide write lock and held it across the backend `GetUserColorPreferences` gRPC call (10s timeout). With one `ColorService` per process and writer-preferring `RWMutex`, a single cold or expired lookup parked every dashboard request — including users with a fresh cache. Failures were never cached, so a backend outage meant every request re-paid the full timeout while holding the global lock.

## Changes

- **RPC moved out of the critical section** (`internal/webui/services/color_service.go`): read under `RLock`; on miss/expiry the backend call runs with no lock held; the write lock is only taken to store the result, re-checking for a concurrent store first (same shape as the earlier `HiddenAlertsService.LoadUserData` fix). Concurrent misses for distinct sessions now fetch in parallel.
- **Negative caching, 15s**: a failed fetch stores a failure marker (`FetchErr` + 15s TTL) in the existing cache entry, so subsequent callers within the window get the cached error immediately and degrade to default severity colors instead of stalling. `InvalidateUserCache` clears the marker.
- **Test seam**: `ColorService.backendClient` becomes a package-private `colorPreferencesFetcher` interface, satisfied implicitly by `*client.BackendClient`. `NewColorService` keeps its concrete parameter; all construction sites unchanged.

Singleflight for same-session concurrent misses is intentionally out of scope per the issue.

## Validation

- New package tests: parallel misses complete in ~one block duration (not N), fresh entries aren't blocked by an in-flight cold fetch, error path issues exactly one RPC per 15s window, `InvalidateUserCache` clears a cached failure, error callers still get `getDefaultSeverityColors` output.
- `go test -race ./internal/webui/services/...` — 44 tests green.
- `go build ./...` — clean.

Closes #53

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>