### PR TITLE
fix(webui): PUT /profile/timezone panics — persist the timezone preference via backend RPC

### DIFF
--- a/internal/backend/database/gorm_db.go
+++ b/internal/backend/database/gorm_db.go
@@ -227,6 +227,10 @@ func (gdb *GormDB) GetUserByID(userID string) (*models.User, error) {
 	return &user, nil
 }
 
+func (gdb *GormDB) UpdateUserTimezone(userID, timezone string) error {
+	return gdb.db.Model(&models.User{}).Where("id = ?", userID).Update("timezone", timezone).Error
+}
+
 func (gdb *GormDB) UpdateLastLogin(userID string) error {
 	now := time.Now()
 	return gdb.db.Model(&models.User{}).Where("id = ?", userID).Update("last_login", &now).Error

--- a/internal/backend/proto/auth/auth.pb.go
+++ b/internal/backend/proto/auth/auth.pb.go
@@ -601,6 +601,110 @@ func (x *GetProfileResponse) GetCommentCount() int64 {
 	return 0
 }
 
+type UpdateTimezoneRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	Timezone      string                 `protobuf:"bytes,2,opt,name=timezone,proto3" json:"timezone,omitempty"` // IANA timezone (e.g., "Europe/Paris")
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateTimezoneRequest) Reset() {
+	*x = UpdateTimezoneRequest{}
+	mi := &file_proto_auth_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateTimezoneRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateTimezoneRequest) ProtoMessage() {}
+
+func (x *UpdateTimezoneRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_auth_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateTimezoneRequest.ProtoReflect.Descriptor instead.
+func (*UpdateTimezoneRequest) Descriptor() ([]byte, []int) {
+	return file_proto_auth_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *UpdateTimezoneRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *UpdateTimezoneRequest) GetTimezone() string {
+	if x != nil {
+		return x.Timezone
+	}
+	return ""
+}
+
+type UpdateTimezoneResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Success       bool                   `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
+	Error         string                 `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateTimezoneResponse) Reset() {
+	*x = UpdateTimezoneResponse{}
+	mi := &file_proto_auth_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateTimezoneResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateTimezoneResponse) ProtoMessage() {}
+
+func (x *UpdateTimezoneResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_auth_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateTimezoneResponse.ProtoReflect.Descriptor instead.
+func (*UpdateTimezoneResponse) Descriptor() ([]byte, []int) {
+	return file_proto_auth_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *UpdateTimezoneResponse) GetSuccess() bool {
+	if x != nil {
+		return x.Success
+	}
+	return false
+}
+
+func (x *UpdateTimezoneResponse) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
 type User struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -617,7 +721,7 @@ type User struct {
 
 func (x *User) Reset() {
 	*x = User{}
-	mi := &file_proto_auth_proto_msgTypes[10]
+	mi := &file_proto_auth_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -629,7 +733,7 @@ func (x *User) String() string {
 func (*User) ProtoMessage() {}
 
 func (x *User) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[10]
+	mi := &file_proto_auth_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -642,7 +746,7 @@ func (x *User) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use User.ProtoReflect.Descriptor instead.
 func (*User) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{10}
+	return file_proto_auth_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *User) GetId() string {
@@ -711,7 +815,7 @@ type SearchUsersRequest struct {
 
 func (x *SearchUsersRequest) Reset() {
 	*x = SearchUsersRequest{}
-	mi := &file_proto_auth_proto_msgTypes[11]
+	mi := &file_proto_auth_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -723,7 +827,7 @@ func (x *SearchUsersRequest) String() string {
 func (*SearchUsersRequest) ProtoMessage() {}
 
 func (x *SearchUsersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[11]
+	mi := &file_proto_auth_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -736,7 +840,7 @@ func (x *SearchUsersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SearchUsersRequest.ProtoReflect.Descriptor instead.
 func (*SearchUsersRequest) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{11}
+	return file_proto_auth_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *SearchUsersRequest) GetQuery() string {
@@ -763,7 +867,7 @@ type SearchUsersResponse struct {
 
 func (x *SearchUsersResponse) Reset() {
 	*x = SearchUsersResponse{}
-	mi := &file_proto_auth_proto_msgTypes[12]
+	mi := &file_proto_auth_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -775,7 +879,7 @@ func (x *SearchUsersResponse) String() string {
 func (*SearchUsersResponse) ProtoMessage() {}
 
 func (x *SearchUsersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[12]
+	mi := &file_proto_auth_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -788,7 +892,7 @@ func (x *SearchUsersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SearchUsersResponse.ProtoReflect.Descriptor instead.
 func (*SearchUsersResponse) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{12}
+	return file_proto_auth_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *SearchUsersResponse) GetUsers() []*User {
@@ -816,7 +920,7 @@ type ListUsersRequest struct {
 
 func (x *ListUsersRequest) Reset() {
 	*x = ListUsersRequest{}
-	mi := &file_proto_auth_proto_msgTypes[13]
+	mi := &file_proto_auth_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -828,7 +932,7 @@ func (x *ListUsersRequest) String() string {
 func (*ListUsersRequest) ProtoMessage() {}
 
 func (x *ListUsersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[13]
+	mi := &file_proto_auth_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -841,7 +945,7 @@ func (x *ListUsersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUsersRequest.ProtoReflect.Descriptor instead.
 func (*ListUsersRequest) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{13}
+	return file_proto_auth_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ListUsersRequest) GetSessionId() string {
@@ -877,7 +981,7 @@ type ListUsersResponse struct {
 
 func (x *ListUsersResponse) Reset() {
 	*x = ListUsersResponse{}
-	mi := &file_proto_auth_proto_msgTypes[14]
+	mi := &file_proto_auth_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -889,7 +993,7 @@ func (x *ListUsersResponse) String() string {
 func (*ListUsersResponse) ProtoMessage() {}
 
 func (x *ListUsersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[14]
+	mi := &file_proto_auth_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -902,7 +1006,7 @@ func (x *ListUsersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUsersResponse.ProtoReflect.Descriptor instead.
 func (*ListUsersResponse) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{14}
+	return file_proto_auth_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ListUsersResponse) GetSuccess() bool {
@@ -944,7 +1048,7 @@ type OAuthAuthURLRequest struct {
 
 func (x *OAuthAuthURLRequest) Reset() {
 	*x = OAuthAuthURLRequest{}
-	mi := &file_proto_auth_proto_msgTypes[15]
+	mi := &file_proto_auth_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -956,7 +1060,7 @@ func (x *OAuthAuthURLRequest) String() string {
 func (*OAuthAuthURLRequest) ProtoMessage() {}
 
 func (x *OAuthAuthURLRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[15]
+	mi := &file_proto_auth_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -969,7 +1073,7 @@ func (x *OAuthAuthURLRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OAuthAuthURLRequest.ProtoReflect.Descriptor instead.
 func (*OAuthAuthURLRequest) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{15}
+	return file_proto_auth_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *OAuthAuthURLRequest) GetProvider() string {
@@ -997,7 +1101,7 @@ type OAuthAuthURLResponse struct {
 
 func (x *OAuthAuthURLResponse) Reset() {
 	*x = OAuthAuthURLResponse{}
-	mi := &file_proto_auth_proto_msgTypes[16]
+	mi := &file_proto_auth_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1009,7 +1113,7 @@ func (x *OAuthAuthURLResponse) String() string {
 func (*OAuthAuthURLResponse) ProtoMessage() {}
 
 func (x *OAuthAuthURLResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[16]
+	mi := &file_proto_auth_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1022,7 +1126,7 @@ func (x *OAuthAuthURLResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OAuthAuthURLResponse.ProtoReflect.Descriptor instead.
 func (*OAuthAuthURLResponse) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{16}
+	return file_proto_auth_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *OAuthAuthURLResponse) GetSuccess() bool {
@@ -1057,7 +1161,7 @@ type OAuthCallbackRequest struct {
 
 func (x *OAuthCallbackRequest) Reset() {
 	*x = OAuthCallbackRequest{}
-	mi := &file_proto_auth_proto_msgTypes[17]
+	mi := &file_proto_auth_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1069,7 +1173,7 @@ func (x *OAuthCallbackRequest) String() string {
 func (*OAuthCallbackRequest) ProtoMessage() {}
 
 func (x *OAuthCallbackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[17]
+	mi := &file_proto_auth_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1082,7 +1186,7 @@ func (x *OAuthCallbackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OAuthCallbackRequest.ProtoReflect.Descriptor instead.
 func (*OAuthCallbackRequest) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{17}
+	return file_proto_auth_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *OAuthCallbackRequest) GetProvider() string {
@@ -1114,7 +1218,7 @@ type GetOAuthProvidersRequest struct {
 
 func (x *GetOAuthProvidersRequest) Reset() {
 	*x = GetOAuthProvidersRequest{}
-	mi := &file_proto_auth_proto_msgTypes[18]
+	mi := &file_proto_auth_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1126,7 +1230,7 @@ func (x *GetOAuthProvidersRequest) String() string {
 func (*GetOAuthProvidersRequest) ProtoMessage() {}
 
 func (x *GetOAuthProvidersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[18]
+	mi := &file_proto_auth_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1139,7 +1243,7 @@ func (x *GetOAuthProvidersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOAuthProvidersRequest.ProtoReflect.Descriptor instead.
 func (*GetOAuthProvidersRequest) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{18}
+	return file_proto_auth_proto_rawDescGZIP(), []int{20}
 }
 
 type GetOAuthProvidersResponse struct {
@@ -1151,7 +1255,7 @@ type GetOAuthProvidersResponse struct {
 
 func (x *GetOAuthProvidersResponse) Reset() {
 	*x = GetOAuthProvidersResponse{}
-	mi := &file_proto_auth_proto_msgTypes[19]
+	mi := &file_proto_auth_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1163,7 +1267,7 @@ func (x *GetOAuthProvidersResponse) String() string {
 func (*GetOAuthProvidersResponse) ProtoMessage() {}
 
 func (x *GetOAuthProvidersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[19]
+	mi := &file_proto_auth_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1176,7 +1280,7 @@ func (x *GetOAuthProvidersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOAuthProvidersResponse.ProtoReflect.Descriptor instead.
 func (*GetOAuthProvidersResponse) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{19}
+	return file_proto_auth_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *GetOAuthProvidersResponse) GetProviders() []*OAuthProvider {
@@ -1194,7 +1298,7 @@ type GetOAuthConfigRequest struct {
 
 func (x *GetOAuthConfigRequest) Reset() {
 	*x = GetOAuthConfigRequest{}
-	mi := &file_proto_auth_proto_msgTypes[20]
+	mi := &file_proto_auth_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1206,7 +1310,7 @@ func (x *GetOAuthConfigRequest) String() string {
 func (*GetOAuthConfigRequest) ProtoMessage() {}
 
 func (x *GetOAuthConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[20]
+	mi := &file_proto_auth_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1219,7 +1323,7 @@ func (x *GetOAuthConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOAuthConfigRequest.ProtoReflect.Descriptor instead.
 func (*GetOAuthConfigRequest) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{20}
+	return file_proto_auth_proto_rawDescGZIP(), []int{22}
 }
 
 type GetOAuthConfigResponse struct {
@@ -1233,7 +1337,7 @@ type GetOAuthConfigResponse struct {
 
 func (x *GetOAuthConfigResponse) Reset() {
 	*x = GetOAuthConfigResponse{}
-	mi := &file_proto_auth_proto_msgTypes[21]
+	mi := &file_proto_auth_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1245,7 +1349,7 @@ func (x *GetOAuthConfigResponse) String() string {
 func (*GetOAuthConfigResponse) ProtoMessage() {}
 
 func (x *GetOAuthConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[21]
+	mi := &file_proto_auth_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1258,7 +1362,7 @@ func (x *GetOAuthConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOAuthConfigResponse.ProtoReflect.Descriptor instead.
 func (*GetOAuthConfigResponse) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{21}
+	return file_proto_auth_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *GetOAuthConfigResponse) GetEnabled() bool {
@@ -1293,7 +1397,7 @@ type OAuthProvider struct {
 
 func (x *OAuthProvider) Reset() {
 	*x = OAuthProvider{}
-	mi := &file_proto_auth_proto_msgTypes[22]
+	mi := &file_proto_auth_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1305,7 +1409,7 @@ func (x *OAuthProvider) String() string {
 func (*OAuthProvider) ProtoMessage() {}
 
 func (x *OAuthProvider) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[22]
+	mi := &file_proto_auth_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1318,7 +1422,7 @@ func (x *OAuthProvider) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OAuthProvider.ProtoReflect.Descriptor instead.
 func (*OAuthProvider) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{22}
+	return file_proto_auth_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *OAuthProvider) GetName() string {
@@ -1352,7 +1456,7 @@ type GetUserGroupsRequest struct {
 
 func (x *GetUserGroupsRequest) Reset() {
 	*x = GetUserGroupsRequest{}
-	mi := &file_proto_auth_proto_msgTypes[23]
+	mi := &file_proto_auth_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1364,7 +1468,7 @@ func (x *GetUserGroupsRequest) String() string {
 func (*GetUserGroupsRequest) ProtoMessage() {}
 
 func (x *GetUserGroupsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[23]
+	mi := &file_proto_auth_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1377,7 +1481,7 @@ func (x *GetUserGroupsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUserGroupsRequest.ProtoReflect.Descriptor instead.
 func (*GetUserGroupsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{23}
+	return file_proto_auth_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *GetUserGroupsRequest) GetUserId() string {
@@ -1396,7 +1500,7 @@ type GetUserGroupsResponse struct {
 
 func (x *GetUserGroupsResponse) Reset() {
 	*x = GetUserGroupsResponse{}
-	mi := &file_proto_auth_proto_msgTypes[24]
+	mi := &file_proto_auth_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1408,7 +1512,7 @@ func (x *GetUserGroupsResponse) String() string {
 func (*GetUserGroupsResponse) ProtoMessage() {}
 
 func (x *GetUserGroupsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[24]
+	mi := &file_proto_auth_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1421,7 +1525,7 @@ func (x *GetUserGroupsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUserGroupsResponse.ProtoReflect.Descriptor instead.
 func (*GetUserGroupsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{24}
+	return file_proto_auth_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *GetUserGroupsResponse) GetGroups() []*UserGroup {
@@ -1445,7 +1549,7 @@ type UserGroup struct {
 
 func (x *UserGroup) Reset() {
 	*x = UserGroup{}
-	mi := &file_proto_auth_proto_msgTypes[25]
+	mi := &file_proto_auth_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1457,7 +1561,7 @@ func (x *UserGroup) String() string {
 func (*UserGroup) ProtoMessage() {}
 
 func (x *UserGroup) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[25]
+	mi := &file_proto_auth_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1470,7 +1574,7 @@ func (x *UserGroup) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserGroup.ProtoReflect.Descriptor instead.
 func (*UserGroup) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{25}
+	return file_proto_auth_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *UserGroup) GetId() string {
@@ -1525,7 +1629,7 @@ type SyncUserGroupsRequest struct {
 
 func (x *SyncUserGroupsRequest) Reset() {
 	*x = SyncUserGroupsRequest{}
-	mi := &file_proto_auth_proto_msgTypes[26]
+	mi := &file_proto_auth_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1537,7 +1641,7 @@ func (x *SyncUserGroupsRequest) String() string {
 func (*SyncUserGroupsRequest) ProtoMessage() {}
 
 func (x *SyncUserGroupsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[26]
+	mi := &file_proto_auth_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1550,7 +1654,7 @@ func (x *SyncUserGroupsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyncUserGroupsRequest.ProtoReflect.Descriptor instead.
 func (*SyncUserGroupsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{26}
+	return file_proto_auth_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *SyncUserGroupsRequest) GetUserId() string {
@@ -1578,7 +1682,7 @@ type SyncUserGroupsResponse struct {
 
 func (x *SyncUserGroupsResponse) Reset() {
 	*x = SyncUserGroupsResponse{}
-	mi := &file_proto_auth_proto_msgTypes[27]
+	mi := &file_proto_auth_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1590,7 +1694,7 @@ func (x *SyncUserGroupsResponse) String() string {
 func (*SyncUserGroupsResponse) ProtoMessage() {}
 
 func (x *SyncUserGroupsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[27]
+	mi := &file_proto_auth_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1603,7 +1707,7 @@ func (x *SyncUserGroupsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyncUserGroupsResponse.ProtoReflect.Descriptor instead.
 func (*SyncUserGroupsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{27}
+	return file_proto_auth_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *SyncUserGroupsResponse) GetSuccess() bool {
@@ -1637,7 +1741,7 @@ type GetUserSentryConfigRequest struct {
 
 func (x *GetUserSentryConfigRequest) Reset() {
 	*x = GetUserSentryConfigRequest{}
-	mi := &file_proto_auth_proto_msgTypes[28]
+	mi := &file_proto_auth_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1649,7 +1753,7 @@ func (x *GetUserSentryConfigRequest) String() string {
 func (*GetUserSentryConfigRequest) ProtoMessage() {}
 
 func (x *GetUserSentryConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[28]
+	mi := &file_proto_auth_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1662,7 +1766,7 @@ func (x *GetUserSentryConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUserSentryConfigRequest.ProtoReflect.Descriptor instead.
 func (*GetUserSentryConfigRequest) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{28}
+	return file_proto_auth_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *GetUserSentryConfigRequest) GetUserId() string {
@@ -1683,7 +1787,7 @@ type GetUserSentryConfigResponse struct {
 
 func (x *GetUserSentryConfigResponse) Reset() {
 	*x = GetUserSentryConfigResponse{}
-	mi := &file_proto_auth_proto_msgTypes[29]
+	mi := &file_proto_auth_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1695,7 +1799,7 @@ func (x *GetUserSentryConfigResponse) String() string {
 func (*GetUserSentryConfigResponse) ProtoMessage() {}
 
 func (x *GetUserSentryConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[29]
+	mi := &file_proto_auth_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1708,7 +1812,7 @@ func (x *GetUserSentryConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUserSentryConfigResponse.ProtoReflect.Descriptor instead.
 func (*GetUserSentryConfigResponse) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{29}
+	return file_proto_auth_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *GetUserSentryConfigResponse) GetSuccess() bool {
@@ -1744,7 +1848,7 @@ type SaveUserSentryConfigRequest struct {
 
 func (x *SaveUserSentryConfigRequest) Reset() {
 	*x = SaveUserSentryConfigRequest{}
-	mi := &file_proto_auth_proto_msgTypes[30]
+	mi := &file_proto_auth_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1756,7 +1860,7 @@ func (x *SaveUserSentryConfigRequest) String() string {
 func (*SaveUserSentryConfigRequest) ProtoMessage() {}
 
 func (x *SaveUserSentryConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[30]
+	mi := &file_proto_auth_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1769,7 +1873,7 @@ func (x *SaveUserSentryConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SaveUserSentryConfigRequest.ProtoReflect.Descriptor instead.
 func (*SaveUserSentryConfigRequest) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{30}
+	return file_proto_auth_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *SaveUserSentryConfigRequest) GetUserId() string {
@@ -1810,7 +1914,7 @@ type SaveUserSentryConfigResponse struct {
 
 func (x *SaveUserSentryConfigResponse) Reset() {
 	*x = SaveUserSentryConfigResponse{}
-	mi := &file_proto_auth_proto_msgTypes[31]
+	mi := &file_proto_auth_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1822,7 +1926,7 @@ func (x *SaveUserSentryConfigResponse) String() string {
 func (*SaveUserSentryConfigResponse) ProtoMessage() {}
 
 func (x *SaveUserSentryConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[31]
+	mi := &file_proto_auth_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1835,7 +1939,7 @@ func (x *SaveUserSentryConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SaveUserSentryConfigResponse.ProtoReflect.Descriptor instead.
 func (*SaveUserSentryConfigResponse) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{31}
+	return file_proto_auth_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *SaveUserSentryConfigResponse) GetSuccess() bool {
@@ -1862,7 +1966,7 @@ type DeleteUserSentryConfigRequest struct {
 
 func (x *DeleteUserSentryConfigRequest) Reset() {
 	*x = DeleteUserSentryConfigRequest{}
-	mi := &file_proto_auth_proto_msgTypes[32]
+	mi := &file_proto_auth_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1874,7 +1978,7 @@ func (x *DeleteUserSentryConfigRequest) String() string {
 func (*DeleteUserSentryConfigRequest) ProtoMessage() {}
 
 func (x *DeleteUserSentryConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[32]
+	mi := &file_proto_auth_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1887,7 +1991,7 @@ func (x *DeleteUserSentryConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteUserSentryConfigRequest.ProtoReflect.Descriptor instead.
 func (*DeleteUserSentryConfigRequest) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{32}
+	return file_proto_auth_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *DeleteUserSentryConfigRequest) GetUserId() string {
@@ -1914,7 +2018,7 @@ type DeleteUserSentryConfigResponse struct {
 
 func (x *DeleteUserSentryConfigResponse) Reset() {
 	*x = DeleteUserSentryConfigResponse{}
-	mi := &file_proto_auth_proto_msgTypes[33]
+	mi := &file_proto_auth_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1926,7 +2030,7 @@ func (x *DeleteUserSentryConfigResponse) String() string {
 func (*DeleteUserSentryConfigResponse) ProtoMessage() {}
 
 func (x *DeleteUserSentryConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[33]
+	mi := &file_proto_auth_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1939,7 +2043,7 @@ func (x *DeleteUserSentryConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteUserSentryConfigResponse.ProtoReflect.Descriptor instead.
 func (*DeleteUserSentryConfigResponse) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{33}
+	return file_proto_auth_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *DeleteUserSentryConfigResponse) GetSuccess() bool {
@@ -1966,7 +2070,7 @@ type GetUserSentryTokenRequest struct {
 
 func (x *GetUserSentryTokenRequest) Reset() {
 	*x = GetUserSentryTokenRequest{}
-	mi := &file_proto_auth_proto_msgTypes[34]
+	mi := &file_proto_auth_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1978,7 +2082,7 @@ func (x *GetUserSentryTokenRequest) String() string {
 func (*GetUserSentryTokenRequest) ProtoMessage() {}
 
 func (x *GetUserSentryTokenRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[34]
+	mi := &file_proto_auth_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1991,7 +2095,7 @@ func (x *GetUserSentryTokenRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUserSentryTokenRequest.ProtoReflect.Descriptor instead.
 func (*GetUserSentryTokenRequest) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{34}
+	return file_proto_auth_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *GetUserSentryTokenRequest) GetUserId() string {
@@ -2020,7 +2124,7 @@ type GetUserSentryTokenResponse struct {
 
 func (x *GetUserSentryTokenResponse) Reset() {
 	*x = GetUserSentryTokenResponse{}
-	mi := &file_proto_auth_proto_msgTypes[35]
+	mi := &file_proto_auth_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2032,7 +2136,7 @@ func (x *GetUserSentryTokenResponse) String() string {
 func (*GetUserSentryTokenResponse) ProtoMessage() {}
 
 func (x *GetUserSentryTokenResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[35]
+	mi := &file_proto_auth_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2045,7 +2149,7 @@ func (x *GetUserSentryTokenResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUserSentryTokenResponse.ProtoReflect.Descriptor instead.
 func (*GetUserSentryTokenResponse) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{35}
+	return file_proto_auth_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *GetUserSentryTokenResponse) GetSuccess() bool {
@@ -2088,7 +2192,7 @@ type UserSentryConfig struct {
 
 func (x *UserSentryConfig) Reset() {
 	*x = UserSentryConfig{}
-	mi := &file_proto_auth_proto_msgTypes[36]
+	mi := &file_proto_auth_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2100,7 +2204,7 @@ func (x *UserSentryConfig) String() string {
 func (*UserSentryConfig) ProtoMessage() {}
 
 func (x *UserSentryConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[36]
+	mi := &file_proto_auth_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2113,7 +2217,7 @@ func (x *UserSentryConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserSentryConfig.ProtoReflect.Descriptor instead.
 func (*UserSentryConfig) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{36}
+	return file_proto_auth_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *UserSentryConfig) GetUserId() string {
@@ -2154,7 +2258,7 @@ type GetConnectedUsersRequest struct {
 
 func (x *GetConnectedUsersRequest) Reset() {
 	*x = GetConnectedUsersRequest{}
-	mi := &file_proto_auth_proto_msgTypes[37]
+	mi := &file_proto_auth_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2166,7 +2270,7 @@ func (x *GetConnectedUsersRequest) String() string {
 func (*GetConnectedUsersRequest) ProtoMessage() {}
 
 func (x *GetConnectedUsersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[37]
+	mi := &file_proto_auth_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2179,7 +2283,7 @@ func (x *GetConnectedUsersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetConnectedUsersRequest.ProtoReflect.Descriptor instead.
 func (*GetConnectedUsersRequest) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{37}
+	return file_proto_auth_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *GetConnectedUsersRequest) GetSessionId() string {
@@ -2201,7 +2305,7 @@ type GetConnectedUsersResponse struct {
 
 func (x *GetConnectedUsersResponse) Reset() {
 	*x = GetConnectedUsersResponse{}
-	mi := &file_proto_auth_proto_msgTypes[38]
+	mi := &file_proto_auth_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2213,7 +2317,7 @@ func (x *GetConnectedUsersResponse) String() string {
 func (*GetConnectedUsersResponse) ProtoMessage() {}
 
 func (x *GetConnectedUsersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[38]
+	mi := &file_proto_auth_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2226,7 +2330,7 @@ func (x *GetConnectedUsersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetConnectedUsersResponse.ProtoReflect.Descriptor instead.
 func (*GetConnectedUsersResponse) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{38}
+	return file_proto_auth_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *GetConnectedUsersResponse) GetSuccess() bool {
@@ -2270,7 +2374,7 @@ type ConnectedUser struct {
 
 func (x *ConnectedUser) Reset() {
 	*x = ConnectedUser{}
-	mi := &file_proto_auth_proto_msgTypes[39]
+	mi := &file_proto_auth_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2282,7 +2386,7 @@ func (x *ConnectedUser) String() string {
 func (*ConnectedUser) ProtoMessage() {}
 
 func (x *ConnectedUser) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_auth_proto_msgTypes[39]
+	mi := &file_proto_auth_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2295,7 +2399,7 @@ func (x *ConnectedUser) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnectedUser.ProtoReflect.Descriptor instead.
 func (*ConnectedUser) Descriptor() ([]byte, []int) {
-	return file_proto_auth_proto_rawDescGZIP(), []int{39}
+	return file_proto_auth_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *ConnectedUser) GetUserId() string {
@@ -2379,7 +2483,14 @@ const file_proto_auth_proto_rawDesc = "" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\"e\n" +
 	"\x12GetProfileResponse\x12*\n" +
 	"\x04user\x18\x01 \x01(\v2\x16.notificator.auth.UserR\x04user\x12#\n" +
-	"\rcomment_count\x18\x02 \x01(\x03R\fcommentCount\"\x9c\x02\n" +
+	"\rcomment_count\x18\x02 \x01(\x03R\fcommentCount\"R\n" +
+	"\x15UpdateTimezoneRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x1a\n" +
+	"\btimezone\x18\x02 \x01(\tR\btimezone\"H\n" +
+	"\x16UpdateTimezoneResponse\x12\x18\n" +
+	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x14\n" +
+	"\x05error\x18\x02 \x01(\tR\x05error\"\x9c\x02\n" +
 	"\x04User\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1a\n" +
 	"\busername\x18\x02 \x01(\tR\busername\x12\x14\n" +
@@ -2502,14 +2613,15 @@ const file_proto_auth_proto_rawDesc = "" +
 	"\busername\x18\x02 \x01(\tR\busername\x12\x14\n" +
 	"\x05email\x18\x03 \x01(\tR\x05email\x12#\n" +
 	"\rsession_count\x18\x04 \x01(\x05R\fsessionCount\x12?\n" +
-	"\rlast_activity\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\flastActivity2\x87\x0e\n" +
+	"\rlast_activity\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\flastActivity2\xec\x0e\n" +
 	"\vAuthService\x12Q\n" +
 	"\bRegister\x12!.notificator.auth.RegisterRequest\x1a\".notificator.auth.RegisterResponse\x12H\n" +
 	"\x05Login\x12\x1e.notificator.auth.LoginRequest\x1a\x1f.notificator.auth.LoginResponse\x12K\n" +
 	"\x06Logout\x12\x1f.notificator.auth.LogoutRequest\x1a .notificator.auth.LogoutResponse\x12f\n" +
 	"\x0fValidateSession\x12(.notificator.auth.ValidateSessionRequest\x1a).notificator.auth.ValidateSessionResponse\x12W\n" +
 	"\n" +
-	"GetProfile\x12#.notificator.auth.GetProfileRequest\x1a$.notificator.auth.GetProfileResponse\x12Z\n" +
+	"GetProfile\x12#.notificator.auth.GetProfileRequest\x1a$.notificator.auth.GetProfileResponse\x12c\n" +
+	"\x0eUpdateTimezone\x12'.notificator.auth.UpdateTimezoneRequest\x1a(.notificator.auth.UpdateTimezoneResponse\x12Z\n" +
 	"\vSearchUsers\x12$.notificator.auth.SearchUsersRequest\x1a%.notificator.auth.SearchUsersResponse\x12T\n" +
 	"\tListUsers\x12\".notificator.auth.ListUsersRequest\x1a#.notificator.auth.ListUsersResponse\x12`\n" +
 	"\x0fGetOAuthAuthURL\x12%.notificator.auth.OAuthAuthURLRequest\x1a&.notificator.auth.OAuthAuthURLResponse\x12X\n" +
@@ -2536,7 +2648,7 @@ func file_proto_auth_proto_rawDescGZIP() []byte {
 	return file_proto_auth_proto_rawDescData
 }
 
-var file_proto_auth_proto_msgTypes = make([]protoimpl.MessageInfo, 40)
+var file_proto_auth_proto_msgTypes = make([]protoimpl.MessageInfo, 42)
 var file_proto_auth_proto_goTypes = []any{
 	(*RegisterRequest)(nil),                // 0: notificator.auth.RegisterRequest
 	(*RegisterResponse)(nil),               // 1: notificator.auth.RegisterResponse
@@ -2548,93 +2660,97 @@ var file_proto_auth_proto_goTypes = []any{
 	(*ValidateSessionResponse)(nil),        // 7: notificator.auth.ValidateSessionResponse
 	(*GetProfileRequest)(nil),              // 8: notificator.auth.GetProfileRequest
 	(*GetProfileResponse)(nil),             // 9: notificator.auth.GetProfileResponse
-	(*User)(nil),                           // 10: notificator.auth.User
-	(*SearchUsersRequest)(nil),             // 11: notificator.auth.SearchUsersRequest
-	(*SearchUsersResponse)(nil),            // 12: notificator.auth.SearchUsersResponse
-	(*ListUsersRequest)(nil),               // 13: notificator.auth.ListUsersRequest
-	(*ListUsersResponse)(nil),              // 14: notificator.auth.ListUsersResponse
-	(*OAuthAuthURLRequest)(nil),            // 15: notificator.auth.OAuthAuthURLRequest
-	(*OAuthAuthURLResponse)(nil),           // 16: notificator.auth.OAuthAuthURLResponse
-	(*OAuthCallbackRequest)(nil),           // 17: notificator.auth.OAuthCallbackRequest
-	(*GetOAuthProvidersRequest)(nil),       // 18: notificator.auth.GetOAuthProvidersRequest
-	(*GetOAuthProvidersResponse)(nil),      // 19: notificator.auth.GetOAuthProvidersResponse
-	(*GetOAuthConfigRequest)(nil),          // 20: notificator.auth.GetOAuthConfigRequest
-	(*GetOAuthConfigResponse)(nil),         // 21: notificator.auth.GetOAuthConfigResponse
-	(*OAuthProvider)(nil),                  // 22: notificator.auth.OAuthProvider
-	(*GetUserGroupsRequest)(nil),           // 23: notificator.auth.GetUserGroupsRequest
-	(*GetUserGroupsResponse)(nil),          // 24: notificator.auth.GetUserGroupsResponse
-	(*UserGroup)(nil),                      // 25: notificator.auth.UserGroup
-	(*SyncUserGroupsRequest)(nil),          // 26: notificator.auth.SyncUserGroupsRequest
-	(*SyncUserGroupsResponse)(nil),         // 27: notificator.auth.SyncUserGroupsResponse
-	(*GetUserSentryConfigRequest)(nil),     // 28: notificator.auth.GetUserSentryConfigRequest
-	(*GetUserSentryConfigResponse)(nil),    // 29: notificator.auth.GetUserSentryConfigResponse
-	(*SaveUserSentryConfigRequest)(nil),    // 30: notificator.auth.SaveUserSentryConfigRequest
-	(*SaveUserSentryConfigResponse)(nil),   // 31: notificator.auth.SaveUserSentryConfigResponse
-	(*DeleteUserSentryConfigRequest)(nil),  // 32: notificator.auth.DeleteUserSentryConfigRequest
-	(*DeleteUserSentryConfigResponse)(nil), // 33: notificator.auth.DeleteUserSentryConfigResponse
-	(*GetUserSentryTokenRequest)(nil),      // 34: notificator.auth.GetUserSentryTokenRequest
-	(*GetUserSentryTokenResponse)(nil),     // 35: notificator.auth.GetUserSentryTokenResponse
-	(*UserSentryConfig)(nil),               // 36: notificator.auth.UserSentryConfig
-	(*GetConnectedUsersRequest)(nil),       // 37: notificator.auth.GetConnectedUsersRequest
-	(*GetConnectedUsersResponse)(nil),      // 38: notificator.auth.GetConnectedUsersResponse
-	(*ConnectedUser)(nil),                  // 39: notificator.auth.ConnectedUser
-	(*timestamppb.Timestamp)(nil),          // 40: google.protobuf.Timestamp
+	(*UpdateTimezoneRequest)(nil),          // 10: notificator.auth.UpdateTimezoneRequest
+	(*UpdateTimezoneResponse)(nil),         // 11: notificator.auth.UpdateTimezoneResponse
+	(*User)(nil),                           // 12: notificator.auth.User
+	(*SearchUsersRequest)(nil),             // 13: notificator.auth.SearchUsersRequest
+	(*SearchUsersResponse)(nil),            // 14: notificator.auth.SearchUsersResponse
+	(*ListUsersRequest)(nil),               // 15: notificator.auth.ListUsersRequest
+	(*ListUsersResponse)(nil),              // 16: notificator.auth.ListUsersResponse
+	(*OAuthAuthURLRequest)(nil),            // 17: notificator.auth.OAuthAuthURLRequest
+	(*OAuthAuthURLResponse)(nil),           // 18: notificator.auth.OAuthAuthURLResponse
+	(*OAuthCallbackRequest)(nil),           // 19: notificator.auth.OAuthCallbackRequest
+	(*GetOAuthProvidersRequest)(nil),       // 20: notificator.auth.GetOAuthProvidersRequest
+	(*GetOAuthProvidersResponse)(nil),      // 21: notificator.auth.GetOAuthProvidersResponse
+	(*GetOAuthConfigRequest)(nil),          // 22: notificator.auth.GetOAuthConfigRequest
+	(*GetOAuthConfigResponse)(nil),         // 23: notificator.auth.GetOAuthConfigResponse
+	(*OAuthProvider)(nil),                  // 24: notificator.auth.OAuthProvider
+	(*GetUserGroupsRequest)(nil),           // 25: notificator.auth.GetUserGroupsRequest
+	(*GetUserGroupsResponse)(nil),          // 26: notificator.auth.GetUserGroupsResponse
+	(*UserGroup)(nil),                      // 27: notificator.auth.UserGroup
+	(*SyncUserGroupsRequest)(nil),          // 28: notificator.auth.SyncUserGroupsRequest
+	(*SyncUserGroupsResponse)(nil),         // 29: notificator.auth.SyncUserGroupsResponse
+	(*GetUserSentryConfigRequest)(nil),     // 30: notificator.auth.GetUserSentryConfigRequest
+	(*GetUserSentryConfigResponse)(nil),    // 31: notificator.auth.GetUserSentryConfigResponse
+	(*SaveUserSentryConfigRequest)(nil),    // 32: notificator.auth.SaveUserSentryConfigRequest
+	(*SaveUserSentryConfigResponse)(nil),   // 33: notificator.auth.SaveUserSentryConfigResponse
+	(*DeleteUserSentryConfigRequest)(nil),  // 34: notificator.auth.DeleteUserSentryConfigRequest
+	(*DeleteUserSentryConfigResponse)(nil), // 35: notificator.auth.DeleteUserSentryConfigResponse
+	(*GetUserSentryTokenRequest)(nil),      // 36: notificator.auth.GetUserSentryTokenRequest
+	(*GetUserSentryTokenResponse)(nil),     // 37: notificator.auth.GetUserSentryTokenResponse
+	(*UserSentryConfig)(nil),               // 38: notificator.auth.UserSentryConfig
+	(*GetConnectedUsersRequest)(nil),       // 39: notificator.auth.GetConnectedUsersRequest
+	(*GetConnectedUsersResponse)(nil),      // 40: notificator.auth.GetConnectedUsersResponse
+	(*ConnectedUser)(nil),                  // 41: notificator.auth.ConnectedUser
+	(*timestamppb.Timestamp)(nil),          // 42: google.protobuf.Timestamp
 }
 var file_proto_auth_proto_depIdxs = []int32{
-	10, // 0: notificator.auth.LoginResponse.user:type_name -> notificator.auth.User
-	40, // 1: notificator.auth.LoginResponse.expires_at:type_name -> google.protobuf.Timestamp
-	10, // 2: notificator.auth.ValidateSessionResponse.user:type_name -> notificator.auth.User
-	10, // 3: notificator.auth.GetProfileResponse.user:type_name -> notificator.auth.User
-	40, // 4: notificator.auth.User.created_at:type_name -> google.protobuf.Timestamp
-	40, // 5: notificator.auth.User.last_login:type_name -> google.protobuf.Timestamp
-	10, // 6: notificator.auth.SearchUsersResponse.users:type_name -> notificator.auth.User
-	10, // 7: notificator.auth.ListUsersResponse.users:type_name -> notificator.auth.User
-	22, // 8: notificator.auth.GetOAuthProvidersResponse.providers:type_name -> notificator.auth.OAuthProvider
-	22, // 9: notificator.auth.GetOAuthConfigResponse.providers:type_name -> notificator.auth.OAuthProvider
-	25, // 10: notificator.auth.GetUserGroupsResponse.groups:type_name -> notificator.auth.UserGroup
-	36, // 11: notificator.auth.GetUserSentryConfigResponse.config:type_name -> notificator.auth.UserSentryConfig
-	40, // 12: notificator.auth.UserSentryConfig.created_at:type_name -> google.protobuf.Timestamp
-	40, // 13: notificator.auth.UserSentryConfig.updated_at:type_name -> google.protobuf.Timestamp
-	39, // 14: notificator.auth.GetConnectedUsersResponse.users:type_name -> notificator.auth.ConnectedUser
-	40, // 15: notificator.auth.ConnectedUser.last_activity:type_name -> google.protobuf.Timestamp
+	12, // 0: notificator.auth.LoginResponse.user:type_name -> notificator.auth.User
+	42, // 1: notificator.auth.LoginResponse.expires_at:type_name -> google.protobuf.Timestamp
+	12, // 2: notificator.auth.ValidateSessionResponse.user:type_name -> notificator.auth.User
+	12, // 3: notificator.auth.GetProfileResponse.user:type_name -> notificator.auth.User
+	42, // 4: notificator.auth.User.created_at:type_name -> google.protobuf.Timestamp
+	42, // 5: notificator.auth.User.last_login:type_name -> google.protobuf.Timestamp
+	12, // 6: notificator.auth.SearchUsersResponse.users:type_name -> notificator.auth.User
+	12, // 7: notificator.auth.ListUsersResponse.users:type_name -> notificator.auth.User
+	24, // 8: notificator.auth.GetOAuthProvidersResponse.providers:type_name -> notificator.auth.OAuthProvider
+	24, // 9: notificator.auth.GetOAuthConfigResponse.providers:type_name -> notificator.auth.OAuthProvider
+	27, // 10: notificator.auth.GetUserGroupsResponse.groups:type_name -> notificator.auth.UserGroup
+	38, // 11: notificator.auth.GetUserSentryConfigResponse.config:type_name -> notificator.auth.UserSentryConfig
+	42, // 12: notificator.auth.UserSentryConfig.created_at:type_name -> google.protobuf.Timestamp
+	42, // 13: notificator.auth.UserSentryConfig.updated_at:type_name -> google.protobuf.Timestamp
+	41, // 14: notificator.auth.GetConnectedUsersResponse.users:type_name -> notificator.auth.ConnectedUser
+	42, // 15: notificator.auth.ConnectedUser.last_activity:type_name -> google.protobuf.Timestamp
 	0,  // 16: notificator.auth.AuthService.Register:input_type -> notificator.auth.RegisterRequest
 	2,  // 17: notificator.auth.AuthService.Login:input_type -> notificator.auth.LoginRequest
 	4,  // 18: notificator.auth.AuthService.Logout:input_type -> notificator.auth.LogoutRequest
 	6,  // 19: notificator.auth.AuthService.ValidateSession:input_type -> notificator.auth.ValidateSessionRequest
 	8,  // 20: notificator.auth.AuthService.GetProfile:input_type -> notificator.auth.GetProfileRequest
-	11, // 21: notificator.auth.AuthService.SearchUsers:input_type -> notificator.auth.SearchUsersRequest
-	13, // 22: notificator.auth.AuthService.ListUsers:input_type -> notificator.auth.ListUsersRequest
-	15, // 23: notificator.auth.AuthService.GetOAuthAuthURL:input_type -> notificator.auth.OAuthAuthURLRequest
-	17, // 24: notificator.auth.AuthService.OAuthCallback:input_type -> notificator.auth.OAuthCallbackRequest
-	18, // 25: notificator.auth.AuthService.GetOAuthProviders:input_type -> notificator.auth.GetOAuthProvidersRequest
-	20, // 26: notificator.auth.AuthService.GetOAuthConfig:input_type -> notificator.auth.GetOAuthConfigRequest
-	23, // 27: notificator.auth.AuthService.GetUserGroups:input_type -> notificator.auth.GetUserGroupsRequest
-	26, // 28: notificator.auth.AuthService.SyncUserGroups:input_type -> notificator.auth.SyncUserGroupsRequest
-	28, // 29: notificator.auth.AuthService.GetUserSentryConfig:input_type -> notificator.auth.GetUserSentryConfigRequest
-	34, // 30: notificator.auth.AuthService.GetUserSentryToken:input_type -> notificator.auth.GetUserSentryTokenRequest
-	30, // 31: notificator.auth.AuthService.SaveUserSentryConfig:input_type -> notificator.auth.SaveUserSentryConfigRequest
-	32, // 32: notificator.auth.AuthService.DeleteUserSentryConfig:input_type -> notificator.auth.DeleteUserSentryConfigRequest
-	37, // 33: notificator.auth.AuthService.GetConnectedUsers:input_type -> notificator.auth.GetConnectedUsersRequest
-	1,  // 34: notificator.auth.AuthService.Register:output_type -> notificator.auth.RegisterResponse
-	3,  // 35: notificator.auth.AuthService.Login:output_type -> notificator.auth.LoginResponse
-	5,  // 36: notificator.auth.AuthService.Logout:output_type -> notificator.auth.LogoutResponse
-	7,  // 37: notificator.auth.AuthService.ValidateSession:output_type -> notificator.auth.ValidateSessionResponse
-	9,  // 38: notificator.auth.AuthService.GetProfile:output_type -> notificator.auth.GetProfileResponse
-	12, // 39: notificator.auth.AuthService.SearchUsers:output_type -> notificator.auth.SearchUsersResponse
-	14, // 40: notificator.auth.AuthService.ListUsers:output_type -> notificator.auth.ListUsersResponse
-	16, // 41: notificator.auth.AuthService.GetOAuthAuthURL:output_type -> notificator.auth.OAuthAuthURLResponse
-	3,  // 42: notificator.auth.AuthService.OAuthCallback:output_type -> notificator.auth.LoginResponse
-	19, // 43: notificator.auth.AuthService.GetOAuthProviders:output_type -> notificator.auth.GetOAuthProvidersResponse
-	21, // 44: notificator.auth.AuthService.GetOAuthConfig:output_type -> notificator.auth.GetOAuthConfigResponse
-	24, // 45: notificator.auth.AuthService.GetUserGroups:output_type -> notificator.auth.GetUserGroupsResponse
-	27, // 46: notificator.auth.AuthService.SyncUserGroups:output_type -> notificator.auth.SyncUserGroupsResponse
-	29, // 47: notificator.auth.AuthService.GetUserSentryConfig:output_type -> notificator.auth.GetUserSentryConfigResponse
-	35, // 48: notificator.auth.AuthService.GetUserSentryToken:output_type -> notificator.auth.GetUserSentryTokenResponse
-	31, // 49: notificator.auth.AuthService.SaveUserSentryConfig:output_type -> notificator.auth.SaveUserSentryConfigResponse
-	33, // 50: notificator.auth.AuthService.DeleteUserSentryConfig:output_type -> notificator.auth.DeleteUserSentryConfigResponse
-	38, // 51: notificator.auth.AuthService.GetConnectedUsers:output_type -> notificator.auth.GetConnectedUsersResponse
-	34, // [34:52] is the sub-list for method output_type
-	16, // [16:34] is the sub-list for method input_type
+	10, // 21: notificator.auth.AuthService.UpdateTimezone:input_type -> notificator.auth.UpdateTimezoneRequest
+	13, // 22: notificator.auth.AuthService.SearchUsers:input_type -> notificator.auth.SearchUsersRequest
+	15, // 23: notificator.auth.AuthService.ListUsers:input_type -> notificator.auth.ListUsersRequest
+	17, // 24: notificator.auth.AuthService.GetOAuthAuthURL:input_type -> notificator.auth.OAuthAuthURLRequest
+	19, // 25: notificator.auth.AuthService.OAuthCallback:input_type -> notificator.auth.OAuthCallbackRequest
+	20, // 26: notificator.auth.AuthService.GetOAuthProviders:input_type -> notificator.auth.GetOAuthProvidersRequest
+	22, // 27: notificator.auth.AuthService.GetOAuthConfig:input_type -> notificator.auth.GetOAuthConfigRequest
+	25, // 28: notificator.auth.AuthService.GetUserGroups:input_type -> notificator.auth.GetUserGroupsRequest
+	28, // 29: notificator.auth.AuthService.SyncUserGroups:input_type -> notificator.auth.SyncUserGroupsRequest
+	30, // 30: notificator.auth.AuthService.GetUserSentryConfig:input_type -> notificator.auth.GetUserSentryConfigRequest
+	36, // 31: notificator.auth.AuthService.GetUserSentryToken:input_type -> notificator.auth.GetUserSentryTokenRequest
+	32, // 32: notificator.auth.AuthService.SaveUserSentryConfig:input_type -> notificator.auth.SaveUserSentryConfigRequest
+	34, // 33: notificator.auth.AuthService.DeleteUserSentryConfig:input_type -> notificator.auth.DeleteUserSentryConfigRequest
+	39, // 34: notificator.auth.AuthService.GetConnectedUsers:input_type -> notificator.auth.GetConnectedUsersRequest
+	1,  // 35: notificator.auth.AuthService.Register:output_type -> notificator.auth.RegisterResponse
+	3,  // 36: notificator.auth.AuthService.Login:output_type -> notificator.auth.LoginResponse
+	5,  // 37: notificator.auth.AuthService.Logout:output_type -> notificator.auth.LogoutResponse
+	7,  // 38: notificator.auth.AuthService.ValidateSession:output_type -> notificator.auth.ValidateSessionResponse
+	9,  // 39: notificator.auth.AuthService.GetProfile:output_type -> notificator.auth.GetProfileResponse
+	11, // 40: notificator.auth.AuthService.UpdateTimezone:output_type -> notificator.auth.UpdateTimezoneResponse
+	14, // 41: notificator.auth.AuthService.SearchUsers:output_type -> notificator.auth.SearchUsersResponse
+	16, // 42: notificator.auth.AuthService.ListUsers:output_type -> notificator.auth.ListUsersResponse
+	18, // 43: notificator.auth.AuthService.GetOAuthAuthURL:output_type -> notificator.auth.OAuthAuthURLResponse
+	3,  // 44: notificator.auth.AuthService.OAuthCallback:output_type -> notificator.auth.LoginResponse
+	21, // 45: notificator.auth.AuthService.GetOAuthProviders:output_type -> notificator.auth.GetOAuthProvidersResponse
+	23, // 46: notificator.auth.AuthService.GetOAuthConfig:output_type -> notificator.auth.GetOAuthConfigResponse
+	26, // 47: notificator.auth.AuthService.GetUserGroups:output_type -> notificator.auth.GetUserGroupsResponse
+	29, // 48: notificator.auth.AuthService.SyncUserGroups:output_type -> notificator.auth.SyncUserGroupsResponse
+	31, // 49: notificator.auth.AuthService.GetUserSentryConfig:output_type -> notificator.auth.GetUserSentryConfigResponse
+	37, // 50: notificator.auth.AuthService.GetUserSentryToken:output_type -> notificator.auth.GetUserSentryTokenResponse
+	33, // 51: notificator.auth.AuthService.SaveUserSentryConfig:output_type -> notificator.auth.SaveUserSentryConfigResponse
+	35, // 52: notificator.auth.AuthService.DeleteUserSentryConfig:output_type -> notificator.auth.DeleteUserSentryConfigResponse
+	40, // 53: notificator.auth.AuthService.GetConnectedUsers:output_type -> notificator.auth.GetConnectedUsersResponse
+	35, // [35:54] is the sub-list for method output_type
+	16, // [16:35] is the sub-list for method input_type
 	16, // [16:16] is the sub-list for extension type_name
 	16, // [16:16] is the sub-list for extension extendee
 	0,  // [0:16] is the sub-list for field type_name
@@ -2651,7 +2767,7 @@ func file_proto_auth_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_auth_proto_rawDesc), len(file_proto_auth_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   40,
+			NumMessages:   42,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/backend/proto/auth/auth_grpc.pb.go
+++ b/internal/backend/proto/auth/auth_grpc.pb.go
@@ -26,6 +26,7 @@ const (
 	AuthService_Logout_FullMethodName                 = "/notificator.auth.AuthService/Logout"
 	AuthService_ValidateSession_FullMethodName        = "/notificator.auth.AuthService/ValidateSession"
 	AuthService_GetProfile_FullMethodName             = "/notificator.auth.AuthService/GetProfile"
+	AuthService_UpdateTimezone_FullMethodName         = "/notificator.auth.AuthService/UpdateTimezone"
 	AuthService_SearchUsers_FullMethodName            = "/notificator.auth.AuthService/SearchUsers"
 	AuthService_ListUsers_FullMethodName              = "/notificator.auth.AuthService/ListUsers"
 	AuthService_GetOAuthAuthURL_FullMethodName        = "/notificator.auth.AuthService/GetOAuthAuthURL"
@@ -52,6 +53,7 @@ type AuthServiceClient interface {
 	Logout(ctx context.Context, in *LogoutRequest, opts ...grpc.CallOption) (*LogoutResponse, error)
 	ValidateSession(ctx context.Context, in *ValidateSessionRequest, opts ...grpc.CallOption) (*ValidateSessionResponse, error)
 	GetProfile(ctx context.Context, in *GetProfileRequest, opts ...grpc.CallOption) (*GetProfileResponse, error)
+	UpdateTimezone(ctx context.Context, in *UpdateTimezoneRequest, opts ...grpc.CallOption) (*UpdateTimezoneResponse, error)
 	SearchUsers(ctx context.Context, in *SearchUsersRequest, opts ...grpc.CallOption) (*SearchUsersResponse, error)
 	ListUsers(ctx context.Context, in *ListUsersRequest, opts ...grpc.CallOption) (*ListUsersResponse, error)
 	// OAuth Methods
@@ -123,6 +125,16 @@ func (c *authServiceClient) GetProfile(ctx context.Context, in *GetProfileReques
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetProfileResponse)
 	err := c.cc.Invoke(ctx, AuthService_GetProfile_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *authServiceClient) UpdateTimezone(ctx context.Context, in *UpdateTimezoneRequest, opts ...grpc.CallOption) (*UpdateTimezoneResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(UpdateTimezoneResponse)
+	err := c.cc.Invoke(ctx, AuthService_UpdateTimezone_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -270,6 +282,7 @@ type AuthServiceServer interface {
 	Logout(context.Context, *LogoutRequest) (*LogoutResponse, error)
 	ValidateSession(context.Context, *ValidateSessionRequest) (*ValidateSessionResponse, error)
 	GetProfile(context.Context, *GetProfileRequest) (*GetProfileResponse, error)
+	UpdateTimezone(context.Context, *UpdateTimezoneRequest) (*UpdateTimezoneResponse, error)
 	SearchUsers(context.Context, *SearchUsersRequest) (*SearchUsersResponse, error)
 	ListUsers(context.Context, *ListUsersRequest) (*ListUsersResponse, error)
 	// OAuth Methods
@@ -311,6 +324,9 @@ func (UnimplementedAuthServiceServer) ValidateSession(context.Context, *Validate
 }
 func (UnimplementedAuthServiceServer) GetProfile(context.Context, *GetProfileRequest) (*GetProfileResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetProfile not implemented")
+}
+func (UnimplementedAuthServiceServer) UpdateTimezone(context.Context, *UpdateTimezoneRequest) (*UpdateTimezoneResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateTimezone not implemented")
 }
 func (UnimplementedAuthServiceServer) SearchUsers(context.Context, *SearchUsersRequest) (*SearchUsersResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SearchUsers not implemented")
@@ -458,6 +474,24 @@ func _AuthService_GetProfile_Handler(srv interface{}, ctx context.Context, dec f
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(AuthServiceServer).GetProfile(ctx, req.(*GetProfileRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AuthService_UpdateTimezone_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpdateTimezoneRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AuthServiceServer).UpdateTimezone(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AuthService_UpdateTimezone_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AuthServiceServer).UpdateTimezone(ctx, req.(*UpdateTimezoneRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -722,6 +756,10 @@ var AuthService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetProfile",
 			Handler:    _AuthService_GetProfile_Handler,
+		},
+		{
+			MethodName: "UpdateTimezone",
+			Handler:    _AuthService_UpdateTimezone_Handler,
 		},
 		{
 			MethodName: "SearchUsers",

--- a/internal/backend/services/services.go
+++ b/internal/backend/services/services.go
@@ -190,7 +190,7 @@ func (s *AuthServiceGorm) ValidateSession(ctx context.Context, req *authpb.Valid
 		}, nil
 	}
 
-	return &authpb.ValidateSessionResponse{
+	resp := &authpb.ValidateSessionResponse{
 		Valid:   true,
 		Message: "Session is valid",
 		User: &authpb.User{
@@ -199,7 +199,11 @@ func (s *AuthServiceGorm) ValidateSession(ctx context.Context, req *authpb.Valid
 			Email:     user.Email,
 			CreatedAt: timestamppb.New(user.CreatedAt),
 		},
-	}, nil
+	}
+	if user.Timezone != nil {
+		resp.User.Timezone = *user.Timezone
+	}
+	return resp, nil
 }
 
 // GetProfile implements the GetProfile RPC method
@@ -217,13 +221,62 @@ func (s *AuthServiceGorm) GetProfile(ctx context.Context, req *authpb.GetProfile
 		}, nil
 	}
 
-	return &authpb.GetProfileResponse{
+	resp := &authpb.GetProfileResponse{
 		User: &authpb.User{
 			Id:        user.ID,
 			Username:  user.Username,
 			Email:     user.Email,
 			CreatedAt: timestamppb.New(user.CreatedAt),
 		},
+	}
+	if user.Timezone != nil {
+		resp.User.Timezone = *user.Timezone
+	}
+	return resp, nil
+}
+
+// UpdateTimezone implements the UpdateTimezone RPC method
+func (s *AuthServiceGorm) UpdateTimezone(ctx context.Context, req *authpb.UpdateTimezoneRequest) (*authpb.UpdateTimezoneResponse, error) {
+	if req.SessionId == "" {
+		return &authpb.UpdateTimezoneResponse{
+			Success: false,
+			Error:   "Session ID is required",
+		}, nil
+	}
+
+	user, err := s.db.GetUserBySession(req.SessionId)
+	if err != nil {
+		return &authpb.UpdateTimezoneResponse{
+			Success: false,
+			Error:   "Invalid session",
+		}, nil
+	}
+
+	if req.Timezone == "" {
+		return &authpb.UpdateTimezoneResponse{
+			Success: false,
+			Error:   "Timezone is required",
+		}, nil
+	}
+
+	// Validate here too: this RPC is reachable without going through the WebUI handler
+	if _, err := time.LoadLocation(req.Timezone); err != nil {
+		return &authpb.UpdateTimezoneResponse{
+			Success: false,
+			Error:   "Invalid timezone: " + req.Timezone,
+		}, nil
+	}
+
+	if err := s.db.UpdateUserTimezone(user.ID, req.Timezone); err != nil {
+		log.Printf("Error updating timezone for user %s: %v", user.ID, err)
+		return &authpb.UpdateTimezoneResponse{
+			Success: false,
+			Error:   "Failed to update timezone",
+		}, nil
+	}
+
+	return &authpb.UpdateTimezoneResponse{
+		Success: true,
 	}, nil
 }
 

--- a/internal/backend/services/update_timezone_test.go
+++ b/internal/backend/services/update_timezone_test.go
@@ -1,0 +1,79 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"notificator/config"
+	"notificator/internal/backend/database"
+	authpb "notificator/internal/backend/proto/auth"
+)
+
+func setupAuthServiceWithSession(t *testing.T) (*AuthServiceGorm, string) {
+	t.Helper()
+
+	db, err := database.NewGormDB("sqlite", config.DatabaseConfig{SQLitePath: t.TempDir() + "/test.db"})
+	if err != nil {
+		t.Fatalf("failed to create test database: %v", err)
+	}
+	if err := db.AutoMigrate(); err != nil {
+		t.Fatalf("failed to migrate test database: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	user, err := db.CreateUser("alice", "alice@example.com", "hash")
+	if err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+	sessionID := "test-session"
+	if err := db.CreateSession(user.ID, sessionID, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("failed to create session: %v", err)
+	}
+
+	return NewAuthServiceGorm(db, nil), sessionID
+}
+
+func TestUpdateTimezone(t *testing.T) {
+	svc, sessionID := setupAuthServiceWithSession(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name        string
+		req         *authpb.UpdateTimezoneRequest
+		wantSuccess bool
+	}{
+		{"missing session", &authpb.UpdateTimezoneRequest{Timezone: "UTC"}, false},
+		{"invalid session", &authpb.UpdateTimezoneRequest{SessionId: "nope", Timezone: "UTC"}, false},
+		{"invalid timezone", &authpb.UpdateTimezoneRequest{SessionId: sessionID, Timezone: "Mars/Olympus"}, false},
+		{"valid", &authpb.UpdateTimezoneRequest{SessionId: sessionID, Timezone: "UTC"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := svc.UpdateTimezone(ctx, tc.req)
+			if err != nil {
+				t.Fatalf("UpdateTimezone: %v", err)
+			}
+			if resp.Success != tc.wantSuccess {
+				t.Fatalf("Success = %v (error %q), want %v", resp.Success, resp.Error, tc.wantSuccess)
+			}
+		})
+	}
+
+	// The rejected Mars/Olympus must not have been persisted; the valid UTC must be.
+	profile, err := svc.GetProfile(ctx, &authpb.GetProfileRequest{SessionId: sessionID})
+	if err != nil {
+		t.Fatalf("GetProfile: %v", err)
+	}
+	if profile.User.Timezone != "UTC" {
+		t.Fatalf("GetProfile timezone = %q, want %q", profile.User.Timezone, "UTC")
+	}
+
+	validate, err := svc.ValidateSession(ctx, &authpb.ValidateSessionRequest{SessionId: sessionID})
+	if err != nil {
+		t.Fatalf("ValidateSession: %v", err)
+	}
+	if validate.User.Timezone != "UTC" {
+		t.Fatalf("ValidateSession timezone = %q, want %q", validate.User.Timezone, "UTC")
+	}
+}

--- a/internal/webui/client/backend_client.go
+++ b/internal/webui/client/backend_client.go
@@ -239,6 +239,9 @@ func (c *BackendClient) ValidateSession(sessionID string) (*User, error) {
 	if resp.User.OauthId != "" {
 		user.OAuthID = &resp.User.OauthId
 	}
+	if resp.User.Timezone != "" {
+		user.Timezone = &resp.User.Timezone
+	}
 
 	return user, nil
 }
@@ -272,8 +275,34 @@ func (c *BackendClient) GetProfile(sessionID string) (*User, error) {
 	if resp.User.OauthId != "" {
 		user.OAuthID = &resp.User.OauthId
 	}
+	if resp.User.Timezone != "" {
+		user.Timezone = &resp.User.Timezone
+	}
 
 	return user, nil
+}
+
+// UpdateTimezone persists the user's IANA timezone preference
+func (c *BackendClient) UpdateTimezone(sessionID, timezone string) error {
+	if c.authClient == nil {
+		return fmt.Errorf("not connected to backend")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := c.authClient.UpdateTimezone(ctx, &authpb.UpdateTimezoneRequest{
+		SessionId: sessionID,
+		Timezone:  timezone,
+	})
+	if err != nil {
+		return err
+	}
+	if !resp.Success {
+		return fmt.Errorf("%s", resp.Error)
+	}
+
+	return nil
 }
 
 // Alert acknowledgment and resolution methods

--- a/internal/webui/handlers/profile_handlers.go
+++ b/internal/webui/handlers/profile_handlers.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/a-h/templ"
 	"github.com/gin-gonic/gin"
-	"gorm.io/gorm"
 
 	"notificator/internal/webui/middleware"
 	"notificator/internal/webui/models"
@@ -122,9 +121,12 @@ func UpdateTimezone(c *gin.Context) {
 		return
 	}
 
-	// Update user timezone in database
-	db := c.MustGet("db").(*gorm.DB)
-	if err := db.Model(user).Update("timezone", req.Timezone).Error; err != nil {
+	if backendClient == nil || !backendClient.IsConnected() {
+		c.JSON(http.StatusServiceUnavailable, models.ErrorResponse("Backend not available"))
+		return
+	}
+
+	if err := backendClient.UpdateTimezone(middleware.GetSessionID(c), req.Timezone); err != nil {
 		c.JSON(http.StatusInternalServerError, models.ErrorResponse("Failed to update timezone"))
 		return
 	}

--- a/proto/auth.proto
+++ b/proto/auth.proto
@@ -14,6 +14,7 @@ service AuthService {
   rpc Logout(LogoutRequest) returns (LogoutResponse);
   rpc ValidateSession(ValidateSessionRequest) returns (ValidateSessionResponse);
   rpc GetProfile(GetProfileRequest) returns (GetProfileResponse);
+  rpc UpdateTimezone(UpdateTimezoneRequest) returns (UpdateTimezoneResponse);
   rpc SearchUsers(SearchUsersRequest) returns (SearchUsersResponse);
   rpc ListUsers(ListUsersRequest) returns (ListUsersResponse);
 
@@ -93,6 +94,16 @@ message GetProfileRequest {
 message GetProfileResponse {
   User user = 1;
   int64 comment_count = 2;
+}
+
+message UpdateTimezoneRequest {
+  string session_id = 1;
+  string timezone = 2;                                              // IANA timezone (e.g., "Europe/Paris")
+}
+
+message UpdateTimezoneResponse {
+  bool success = 1;
+  string error = 2;
 }
 
 message User {


### PR DESCRIPTION
## Problem

`PUT /api/v1/profile/timezone` panicked on every call: the handler did `c.MustGet("db").(*gorm.DB)` but no middleware ever sets `"db"` — the WebUI is an all-gRPC client with no database handle. `gin.Recovery()` turned the panic into a 500 plus a stack trace in the log on every timezone selection. Independently, nothing ever read or wrote `users.timezone`, so the preference reset to the browser timezone on every reload and the statistics dashboard's time-of-day bucketing changed per device.

## Changes

- **Proto** (`proto/auth.proto`): new `UpdateTimezone` RPC on `AuthService` with `UpdateTimezoneRequest{session_id, timezone}` / `UpdateTimezoneResponse{success, error}`; regenerated with `make proto`.
- **Backend** (`internal/backend/services/services.go`): `UpdateTimezone` validates the `session_id` like the neighbouring RPCs (there is no auth interceptor), validates the timezone with `time.LoadLocation` server-side (the RPC is reachable without the WebUI), and persists via the new `GormDB.UpdateUserTimezone`.
- **Read path**: `GetProfile` and `ValidateSession` now populate `timezone`, and `internal/webui/client/backend_client.go` maps it into `client.User`, so `GET /api/v1/profile/timezone` returns the stored value instead of `""`.
- **WebUI handler** (`internal/webui/handlers/profile_handlers.go`): `UpdateTimezone` now calls the backend client, keeping the existing `time.LoadLocation` check as a cheap 400 before the round-trip; the `gorm.io/gorm` import — the only one in `internal/webui/` — is gone.
- **Test** (`internal/backend/services/update_timezone_test.go`): covers missing/invalid session, invalid timezone (`Mars/Olympus`) not persisted, and the stored value round-tripping through both `GetProfile` and `ValidateSession`.

## Validation

- `go build ./...` clean; `go test ./internal/backend/...` — 12 passed.
- `rg 'MustGet\("db"\)' internal/webui/` and `rg gorm internal/webui/` both return nothing.

Closes #36

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>