### PR TITLE
perf(alertmanager): fan out multi-Alertmanager polls concurrently

### DIFF
--- a/internal/alertmanager/client.go
+++ b/internal/alertmanager/client.go
@@ -585,6 +585,11 @@ func (c *Client) DeleteSilence(silenceID string) error {
 // of the full payload.
 const healthCheckFilter = `alertname="__notificator_health_check__"`
 
+// healthCheckDrainLimit caps how much of the probe response we read. A backend
+// that honours the filter answers with a handful of bytes; one that silently
+// ignores it would otherwise have us pull the entire alert set on every probe.
+const healthCheckDrainLimit = 4 << 10
+
 func (c *Client) TestConnection() error {
 	url := fmt.Sprintf("%s/api/v2/alerts?filter=%s", c.BaseURL, neturl.QueryEscape(healthCheckFilter))
 
@@ -606,8 +611,10 @@ func (c *Client) TestConnection() error {
 		return fmt.Errorf("alertmanager returned status %d: %s", resp.StatusCode, string(body[:min(200, len(body))]))
 	}
 
-	// Drain the body so the connection goes back to the keep-alive pool.
-	_, _ = io.Copy(io.Discard, resp.Body)
+	// Drain a bounded amount so the connection goes back to the keep-alive pool
+	// without downloading a full payload from a backend that ignored the filter.
+	// Past that ceiling, letting the transport abandon the connection is cheaper.
+	_, _ = io.CopyN(io.Discard, resp.Body, healthCheckDrainLimit)
 
 	return nil
 }

--- a/internal/alertmanager/client.go
+++ b/internal/alertmanager/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	neturl "net/url"
 	"strings"
 	"sync"
 	"time"
@@ -578,8 +579,14 @@ func (c *Client) DeleteSilence(silenceID string) error {
 	return nil
 }
 
+// healthCheckFilter keeps the health probe cheap: the alerts endpoint is the
+// only one guaranteed to exist across Alertmanager, Cortex and Mimir, but a
+// filter that cannot match anything makes it answer with an empty list instead
+// of the full payload.
+const healthCheckFilter = `alertname="__notificator_health_check__"`
+
 func (c *Client) TestConnection() error {
-	url := fmt.Sprintf("%s/api/v2/alerts", c.BaseURL) // v2 API doesn't have dedicated status endpoint
+	url := fmt.Sprintf("%s/api/v2/alerts?filter=%s", c.BaseURL, neturl.QueryEscape(healthCheckFilter))
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -598,6 +605,9 @@ func (c *Client) TestConnection() error {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("alertmanager returned status %d: %s", resp.StatusCode, string(body[:min(200, len(body))]))
 	}
+
+	// Drain the body so the connection goes back to the keep-alive pool.
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return nil
 }
@@ -673,27 +683,76 @@ type SilenceWithSource struct {
 	Source  string // Name of the Alertmanager instance
 }
 
+type namedClient struct {
+	name   string
+	client *Client
+}
+
+type fanOutResult[T any] struct {
+	name  string
+	value T
+	err   error
+}
+
+// snapshotClients copies the client map under RLock so fan-outs can do their
+// HTTP work without holding mc.mutex, which would otherwise block
+// UpdateFromConfig for the whole N x timeout window.
+func (mc *MultiClient) snapshotClients() []namedClient {
+	mc.mutex.RLock()
+	defer mc.mutex.RUnlock()
+
+	snapshot := make([]namedClient, 0, len(mc.clients))
+	for name, client := range mc.clients {
+		snapshot = append(snapshot, namedClient{name: name, client: client})
+	}
+
+	return snapshot
+}
+
+// fanOut calls fn against every client concurrently and returns the results in
+// snapshot order, so the wall-clock cost is max(latency) rather than
+// sum(latency). Concurrency is unbounded on purpose: the fleet size is the
+// number of configured Alertmanagers, which is small by construction.
+func fanOut[T any](clients []namedClient, fn func(*Client) (T, error)) []fanOutResult[T] {
+	results := make([]fanOutResult[T], len(clients))
+
+	var wg sync.WaitGroup
+	for i, nc := range clients {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			value, err := fn(nc.client)
+			results[i] = fanOutResult[T]{name: nc.name, value: value, err: err}
+		}()
+	}
+	wg.Wait()
+
+	return results
+}
+
+func testConnections(clients []namedClient) []fanOutResult[struct{}] {
+	return fanOut(clients, func(c *Client) (struct{}, error) {
+		return struct{}{}, c.TestConnection()
+	})
+}
+
 // FetchAllAlertsDetailed fetches alerts from every configured Alertmanager and
 // reports per-source failures instead of collapsing them into a single error,
 // so callers can tell a partial fetch from a genuinely empty one.
 func (mc *MultiClient) FetchAllAlertsDetailed() ([]AlertWithSource, map[string]error) {
-	mc.mutex.RLock()
-	defer mc.mutex.RUnlock()
-
 	var allAlerts []AlertWithSource
 	failedSources := make(map[string]error)
 
-	for name, client := range mc.clients {
-		alerts, err := client.FetchAlerts()
-		if err != nil {
-			failedSources[name] = err
+	for _, result := range fanOut(mc.snapshotClients(), (*Client).FetchAlerts) {
+		if result.err != nil {
+			failedSources[result.name] = result.err
 			continue
 		}
 
-		for _, alert := range alerts {
+		for _, alert := range result.value {
 			allAlerts = append(allAlerts, AlertWithSource{
 				Alert:  alert,
-				Source: name,
+				Source: result.name,
 			})
 		}
 	}
@@ -733,23 +792,19 @@ func (mc *MultiClient) FetchAllActiveAlerts() ([]AlertWithSource, error) {
 // reports per-source failures instead of collapsing them into a single error, so an
 // unreachable Alertmanager degrades that source instead of blanking the inventory.
 func (mc *MultiClient) FetchAllSilencesDetailed() ([]SilenceWithSource, map[string]error) {
-	mc.mutex.RLock()
-	defer mc.mutex.RUnlock()
-
 	var allSilences []SilenceWithSource
 	failedSources := make(map[string]error)
 
-	for name, client := range mc.clients {
-		silences, err := client.FetchSilences()
-		if err != nil {
-			failedSources[name] = err
+	for _, result := range fanOut(mc.snapshotClients(), (*Client).FetchSilences) {
+		if result.err != nil {
+			failedSources[result.name] = result.err
 			continue
 		}
 
-		for _, silence := range silences {
+		for _, silence := range result.value {
 			allSilences = append(allSilences, SilenceWithSource{
 				Silence: silence,
-				Source:  name,
+				Source:  result.name,
 			})
 		}
 	}
@@ -758,13 +813,10 @@ func (mc *MultiClient) FetchAllSilencesDetailed() ([]SilenceWithSource, map[stri
 }
 
 func (mc *MultiClient) TestAllConnections() map[string]error {
-	mc.mutex.RLock()
-	defer mc.mutex.RUnlock()
-
 	results := make(map[string]error)
 
-	for name, client := range mc.clients {
-		results[name] = client.TestConnection()
+	for _, result := range testConnections(mc.snapshotClients()) {
+		results[result.name] = result.err
 	}
 
 	return results
@@ -835,25 +887,21 @@ func (c *Client) IsHealthy() bool {
 }
 
 func (mc *MultiClient) GetHealthStatus() map[string]bool {
-	mc.mutex.RLock()
-	defer mc.mutex.RUnlock()
-
 	status := make(map[string]bool)
-	for name, client := range mc.clients {
-		status[name] = client.IsHealthy()
+	for _, result := range testConnections(mc.snapshotClients()) {
+		status[result.name] = result.err == nil
 	}
 
 	return status
 }
 
 func (mc *MultiClient) GetHealthyClients() map[string]*Client {
-	mc.mutex.RLock()
-	defer mc.mutex.RUnlock()
+	clients := mc.snapshotClients()
 
 	healthy := make(map[string]*Client)
-	for name, client := range mc.clients {
-		if client.IsHealthy() {
-			healthy[name] = client
+	for i, result := range testConnections(clients) {
+		if result.err == nil {
+			healthy[result.name] = clients[i].client
 		}
 	}
 

--- a/internal/alertmanager/client_test.go
+++ b/internal/alertmanager/client_test.go
@@ -91,28 +91,34 @@ func TestFetchAllAlertsDetailedIsConcurrent(t *testing.T) {
 }
 
 func TestFetchAllAlertsDetailedPartialFailure(t *testing.T) {
-	// A source whose handler outlives the client timeout stands in for an
-	// unreachable Alertmanager.
+	// Sources whose handlers outlive the client timeout stand in for unreachable
+	// Alertmanagers. Two of them, so serialising stacks both timeouts on top of
+	// the healthy latencies (~1.1s) and trips the bound below, while a concurrent
+	// fan-out stays at roughly one timeout.
 	hang := make(chan struct{})
-	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tarpit := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		<-hang
-	}))
+	})
+	deadA := httptest.NewServer(tarpit)
+	deadB := httptest.NewServer(tarpit)
 	defer func() {
 		close(hang)
-		dead.Close()
+		deadA.Close()
+		deadB.Close()
 	}()
 
 	urls := map[string]string{
 		"healthy-a": alertmanagerStub(t, "healthy-a", 50*time.Millisecond).URL,
 		"healthy-b": alertmanagerStub(t, "healthy-b", 50*time.Millisecond).URL,
-		"dead":      dead.URL,
+		"dead-a":    deadA.URL,
+		"dead-b":    deadB.URL,
 	}
 
 	const deadTimeout = 500 * time.Millisecond
 
 	mc := multiClientFor(urls)
 	for _, nc := range mc.snapshotClients() {
-		if nc.name == "dead" {
+		if strings.HasPrefix(nc.name, "dead") {
 			nc.client.HTTPClient.Timeout = deadTimeout
 		}
 	}
@@ -125,19 +131,21 @@ func TestFetchAllAlertsDetailedPartialFailure(t *testing.T) {
 		t.Fatalf("got %d alerts, want the 2 healthy ones", len(alerts))
 	}
 	for _, a := range alerts {
-		if a.Source == "dead" {
+		if strings.HasPrefix(a.Source, "dead") {
 			t.Fatalf("dead source contributed alerts: %+v", a)
 		}
 	}
-	if _, ok := failed["dead"]; !ok {
-		t.Fatalf("dead source missing from failedSources: %v", failed)
+	for _, name := range []string{"dead-a", "dead-b"} {
+		if _, ok := failed[name]; !ok {
+			t.Fatalf("%s missing from failedSources: %v", name, failed)
+		}
 	}
-	if len(failed) != 1 {
+	if len(failed) != 2 {
 		t.Fatalf("unexpected failures: %v", failed)
 	}
-	// Bounded by the single timeout, not timeout + healthy latencies. The bound
-	// is derived from the timeout so the intent stays "did not serialise" rather
-	// than a hand-tuned number that a slow runner can trip.
+	// Bounded by a single timeout, not both timeouts plus the healthy latencies.
+	// The bound is derived from the timeout so the intent stays "did not
+	// serialise" rather than a hand-tuned number that a slow runner can trip.
 	if elapsed > 2*deadTimeout {
 		t.Fatalf("fan-out took %s, want it bounded by the dead source timeout %s", elapsed, deadTimeout)
 	}

--- a/internal/alertmanager/client_test.go
+++ b/internal/alertmanager/client_test.go
@@ -4,12 +4,17 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"notificator/config"
 )
+
+func alertJSON(name string) string {
+	return fmt.Sprintf(`[{"fingerprint":"fp-%s","labels":{"alertname":"%s"},"status":{"state":"active"}}]`, name, name)
+}
 
 // alertmanagerStub serves a single alert named after the instance, after delay.
 func alertmanagerStub(t *testing.T, name string, delay time.Duration) *httptest.Server {
@@ -18,7 +23,24 @@ func alertmanagerStub(t *testing.T, name string, delay time.Duration) *httptest.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(delay)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `[{"fingerprint":"fp-%s","labels":{"alertname":"%s"},"status":{"state":"active"}}]`, name, name)
+		fmt.Fprint(w, alertJSON(name))
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+// barrierStub only answers once every peer stub is also serving, so a fan-out
+// that regressed to a sequential loop deadlocks on the first source and fails
+// on its client timeout instead of merely being slow.
+func barrierStub(t *testing.T, name string, barrier *sync.WaitGroup) *httptest.Server {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		barrier.Done()
+		barrier.Wait()
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, alertJSON(name))
 	}))
 	t.Cleanup(srv.Close)
 
@@ -35,8 +57,6 @@ func multiClientFor(urls map[string]string) *MultiClient {
 }
 
 func TestFetchAllAlertsDetailedIsConcurrent(t *testing.T) {
-	const delay = 300 * time.Millisecond
-
 	tests := []struct {
 		name    string
 		sources int
@@ -47,25 +67,24 @@ func TestFetchAllAlertsDetailedIsConcurrent(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			// Every source must be in flight at once for any of them to answer,
+			// so this asserts observed concurrency rather than wall-clock.
+			var barrier sync.WaitGroup
+			barrier.Add(tc.sources)
+
 			urls := make(map[string]string, tc.sources)
 			for i := 0; i < tc.sources; i++ {
 				name := fmt.Sprintf("am-%d", i)
-				urls[name] = alertmanagerStub(t, name, delay).URL
+				urls[name] = barrierStub(t, name, &barrier).URL
 			}
 
-			start := time.Now()
 			alerts, failed := multiClientFor(urls).FetchAllAlertsDetailed()
-			elapsed := time.Since(start)
 
 			if len(failed) != 0 {
-				t.Fatalf("unexpected failures: %v", failed)
+				t.Fatalf("sources did not run concurrently (a serial fan-out stalls on the barrier): %v", failed)
 			}
 			if len(alerts) != tc.sources {
 				t.Fatalf("got %d alerts, want %d", len(alerts), tc.sources)
-			}
-			// Serial would be sources*delay; concurrent stays near one delay.
-			if max := time.Duration(float64(delay) * 1.8); elapsed > max {
-				t.Fatalf("fan-out took %s, want under %s (serial would be %s)", elapsed, max, time.Duration(tc.sources)*delay)
 			}
 		})
 	}
@@ -122,7 +141,12 @@ func TestFetchAllAlertsDetailedPartialFailure(t *testing.T) {
 
 func TestFanOutDoesNotHoldMutexAcrossHTTP(t *testing.T) {
 	release := make(chan struct{})
+	// serving proves the fan-out is inside the HTTP call before the writer races
+	// it; without it the write lock may be taken before the fetch ever starts and
+	// the test passes regardless of where the mutex is held.
+	serving := make(chan struct{})
 	slow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(serving)
 		<-release
 		fmt.Fprint(w, `[]`)
 	}))
@@ -130,12 +154,18 @@ func TestFanOutDoesNotHoldMutexAcrossHTTP(t *testing.T) {
 
 	mc := multiClientFor(map[string]string{"slow": slow.URL})
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		mc.FetchAllAlertsDetailed()
-	}()
+	// Deferred so a t.Fatal below still unblocks the handler, letting the
+	// deferred slow.Close() return; otherwise a regression reads as a hung
+	// package instead of a failed assertion.
+	defer close(release)
+
+	go mc.FetchAllAlertsDetailed()
+
+	select {
+	case <-serving:
+	case <-time.After(5 * time.Second):
+		t.Fatal("fan-out never reached the HTTP handler")
+	}
 
 	// UpdateFromConfig needs the write lock; it must not wait on the in-flight fetch.
 	updated := make(chan struct{})
@@ -149,15 +179,17 @@ func TestFanOutDoesNotHoldMutexAcrossHTTP(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("UpdateFromConfig blocked behind an in-flight fan-out")
 	}
-
-	close(release)
-	wg.Wait()
 }
 
-func TestTestConnectionDrainsBody(t *testing.T) {
+func TestTestConnectionUsesHealthFilterAndReusesConnection(t *testing.T) {
+	var mu sync.Mutex
 	var filter string
+	var addrs []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		filter = r.URL.Query().Get("filter")
+		addrs = append(addrs, r.RemoteAddr)
+		mu.Unlock()
 		fmt.Fprint(w, `[]`)
 	}))
 	defer srv.Close()
@@ -166,13 +198,56 @@ func TestTestConnectionDrainsBody(t *testing.T) {
 	if err := client.TestConnection(); err != nil {
 		t.Fatalf("TestConnection: %v", err)
 	}
+	if err := client.TestConnection(); err != nil {
+		t.Fatalf("second TestConnection: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
 	if filter != healthCheckFilter {
 		t.Fatalf("health probe filter = %q, want %q", filter, healthCheckFilter)
 	}
+	if len(addrs) != 2 {
+		t.Fatalf("got %d probes, want 2: %v", len(addrs), addrs)
+	}
+	// Same client port means the drained body put the connection back in the
+	// keep-alive pool; dropping the drain makes the transport dial a fresh one.
+	if addrs[0] != addrs[1] {
+		t.Fatalf("probe dialled a new connection instead of reusing one: %v", addrs)
+	}
+}
 
-	// A drained + closed body is reused, so the second probe rides the same connection.
-	if err := client.TestConnection(); err != nil {
-		t.Fatalf("second TestConnection: %v", err)
+func TestTestConnectionBoundsDrainOfIgnoredFilter(t *testing.T) {
+	// A backend that silently ignores the filter answers with the full alert set.
+	// The probe must stop reading at healthCheckDrainLimit, which is observable:
+	// an incompletely read body cannot go back to the keep-alive pool, so the
+	// second probe dials a new connection. An unbounded drain would reuse it.
+	body := strings.Repeat("x", 64*healthCheckDrainLimit)
+
+	var mu sync.Mutex
+	var addrs []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		addrs = append(addrs, r.RemoteAddr)
+		mu.Unlock()
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL)
+	for i := 0; i < 2; i++ {
+		if err := client.TestConnection(); err != nil {
+			t.Fatalf("TestConnection %d: %v", i, err)
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(addrs) != 2 {
+		t.Fatalf("got %d probes, want 2: %v", len(addrs), addrs)
+	}
+	if addrs[0] == addrs[1] {
+		t.Fatalf("probe drained the whole %d-byte payload instead of stopping at %d bytes", len(body), healthCheckDrainLimit)
 	}
 }
 

--- a/internal/alertmanager/client_test.go
+++ b/internal/alertmanager/client_test.go
@@ -1,0 +1,218 @@
+package alertmanager
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"notificator/config"
+)
+
+// alertmanagerStub serves a single alert named after the instance, after delay.
+func alertmanagerStub(t *testing.T, name string, delay time.Duration) *httptest.Server {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(delay)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `[{"fingerprint":"fp-%s","labels":{"alertname":"%s"},"status":{"state":"active"}}]`, name, name)
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+func multiClientFor(urls map[string]string) *MultiClient {
+	cfg := &config.Config{}
+	for name, url := range urls {
+		cfg.Alertmanagers = append(cfg.Alertmanagers, config.AlertmanagerConfig{Name: name, URL: url})
+	}
+
+	return NewMultiClient(cfg)
+}
+
+func TestFetchAllAlertsDetailedIsConcurrent(t *testing.T) {
+	const delay = 300 * time.Millisecond
+
+	tests := []struct {
+		name    string
+		sources int
+	}{
+		{name: "two sources", sources: 2},
+		{name: "five sources", sources: 5},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			urls := make(map[string]string, tc.sources)
+			for i := 0; i < tc.sources; i++ {
+				name := fmt.Sprintf("am-%d", i)
+				urls[name] = alertmanagerStub(t, name, delay).URL
+			}
+
+			start := time.Now()
+			alerts, failed := multiClientFor(urls).FetchAllAlertsDetailed()
+			elapsed := time.Since(start)
+
+			if len(failed) != 0 {
+				t.Fatalf("unexpected failures: %v", failed)
+			}
+			if len(alerts) != tc.sources {
+				t.Fatalf("got %d alerts, want %d", len(alerts), tc.sources)
+			}
+			// Serial would be sources*delay; concurrent stays near one delay.
+			if max := time.Duration(float64(delay) * 1.8); elapsed > max {
+				t.Fatalf("fan-out took %s, want under %s (serial would be %s)", elapsed, max, time.Duration(tc.sources)*delay)
+			}
+		})
+	}
+}
+
+func TestFetchAllAlertsDetailedPartialFailure(t *testing.T) {
+	// A source whose handler outlives the client timeout stands in for an
+	// unreachable Alertmanager.
+	hang := make(chan struct{})
+	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-hang
+	}))
+	defer func() {
+		close(hang)
+		dead.Close()
+	}()
+
+	urls := map[string]string{
+		"healthy-a": alertmanagerStub(t, "healthy-a", 50*time.Millisecond).URL,
+		"healthy-b": alertmanagerStub(t, "healthy-b", 50*time.Millisecond).URL,
+		"dead":      dead.URL,
+	}
+
+	mc := multiClientFor(urls)
+	for _, nc := range mc.snapshotClients() {
+		if nc.name == "dead" {
+			nc.client.HTTPClient.Timeout = 500 * time.Millisecond
+		}
+	}
+
+	start := time.Now()
+	alerts, failed := mc.FetchAllAlertsDetailed()
+	elapsed := time.Since(start)
+
+	if len(alerts) != 2 {
+		t.Fatalf("got %d alerts, want the 2 healthy ones", len(alerts))
+	}
+	for _, a := range alerts {
+		if a.Source == "dead" {
+			t.Fatalf("dead source contributed alerts: %+v", a)
+		}
+	}
+	if _, ok := failed["dead"]; !ok {
+		t.Fatalf("dead source missing from failedSources: %v", failed)
+	}
+	if len(failed) != 1 {
+		t.Fatalf("unexpected failures: %v", failed)
+	}
+	// Bounded by the single timeout, not timeout + healthy latencies.
+	if elapsed > 900*time.Millisecond {
+		t.Fatalf("fan-out took %s, want it bounded by the dead source timeout", elapsed)
+	}
+}
+
+func TestFanOutDoesNotHoldMutexAcrossHTTP(t *testing.T) {
+	release := make(chan struct{})
+	slow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+		fmt.Fprint(w, `[]`)
+	}))
+	defer slow.Close()
+
+	mc := multiClientFor(map[string]string{"slow": slow.URL})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		mc.FetchAllAlertsDetailed()
+	}()
+
+	// UpdateFromConfig needs the write lock; it must not wait on the in-flight fetch.
+	updated := make(chan struct{})
+	go func() {
+		mc.UpdateFromConfig(&config.Config{})
+		close(updated)
+	}()
+
+	select {
+	case <-updated:
+	case <-time.After(2 * time.Second):
+		t.Fatal("UpdateFromConfig blocked behind an in-flight fan-out")
+	}
+
+	close(release)
+	wg.Wait()
+}
+
+func TestTestConnectionDrainsBody(t *testing.T) {
+	var filter string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		filter = r.URL.Query().Get("filter")
+		fmt.Fprint(w, `[]`)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL)
+	if err := client.TestConnection(); err != nil {
+		t.Fatalf("TestConnection: %v", err)
+	}
+	if filter != healthCheckFilter {
+		t.Fatalf("health probe filter = %q, want %q", filter, healthCheckFilter)
+	}
+
+	// A drained + closed body is reused, so the second probe rides the same connection.
+	if err := client.TestConnection(); err != nil {
+		t.Fatalf("second TestConnection: %v", err)
+	}
+}
+
+func TestGetHealthStatusConcurrent(t *testing.T) {
+	const delay = 300 * time.Millisecond
+
+	urls := map[string]string{}
+	for i := 0; i < 4; i++ {
+		name := fmt.Sprintf("am-%d", i)
+		urls[name] = alertmanagerStub(t, name, delay).URL
+	}
+	broken := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer broken.Close()
+	urls["broken"] = broken.URL
+
+	mc := multiClientFor(urls)
+
+	start := time.Now()
+	status := mc.GetHealthStatus()
+	elapsed := time.Since(start)
+
+	if len(status) != len(urls) {
+		t.Fatalf("got %d statuses, want %d", len(status), len(urls))
+	}
+	if status["broken"] {
+		t.Fatal("broken source reported healthy")
+	}
+	if elapsed > time.Duration(float64(delay)*1.8) {
+		t.Fatalf("health fan-out took %s, want near %s", elapsed, delay)
+	}
+
+	healthy := mc.GetHealthyClients()
+	if len(healthy) != 4 {
+		t.Fatalf("got %d healthy clients, want 4: %v", len(healthy), healthy)
+	}
+	for name, client := range healthy {
+		if client == nil || client.BaseURL != urls[name] {
+			t.Fatalf("healthy client %q maps to the wrong instance: %+v", name, client)
+		}
+	}
+}

--- a/internal/alertmanager/client_test.go
+++ b/internal/alertmanager/client_test.go
@@ -108,10 +108,12 @@ func TestFetchAllAlertsDetailedPartialFailure(t *testing.T) {
 		"dead":      dead.URL,
 	}
 
+	const deadTimeout = 500 * time.Millisecond
+
 	mc := multiClientFor(urls)
 	for _, nc := range mc.snapshotClients() {
 		if nc.name == "dead" {
-			nc.client.HTTPClient.Timeout = 500 * time.Millisecond
+			nc.client.HTTPClient.Timeout = deadTimeout
 		}
 	}
 
@@ -133,9 +135,11 @@ func TestFetchAllAlertsDetailedPartialFailure(t *testing.T) {
 	if len(failed) != 1 {
 		t.Fatalf("unexpected failures: %v", failed)
 	}
-	// Bounded by the single timeout, not timeout + healthy latencies.
-	if elapsed > 900*time.Millisecond {
-		t.Fatalf("fan-out took %s, want it bounded by the dead source timeout", elapsed)
+	// Bounded by the single timeout, not timeout + healthy latencies. The bound
+	// is derived from the timeout so the intent stays "did not serialise" rather
+	// than a hand-tuned number that a slow runner can trip.
+	if elapsed > 2*deadTimeout {
+		t.Fatalf("fan-out took %s, want it bounded by the dead source timeout %s", elapsed, deadTimeout)
 	}
 }
 
@@ -252,13 +256,20 @@ func TestTestConnectionBoundsDrainOfIgnoredFilter(t *testing.T) {
 }
 
 func TestGetHealthStatusConcurrent(t *testing.T) {
-	const delay = 300 * time.Millisecond
+	const probed = 4
+
+	// Same barrier trick as the fetch fan-out: every probed source must be in
+	// flight at once for any of them to answer, so a serial regression stalls
+	// on the client timeout instead of merely being slow.
+	var barrier sync.WaitGroup
+	barrier.Add(probed)
 
 	urls := map[string]string{}
-	for i := 0; i < 4; i++ {
+	for i := 0; i < probed; i++ {
 		name := fmt.Sprintf("am-%d", i)
-		urls[name] = alertmanagerStub(t, name, delay).URL
+		urls[name] = barrierStub(t, name, &barrier).URL
 	}
+	// The broken source answers immediately and must not join the barrier.
 	broken := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "boom", http.StatusInternalServerError)
 	}))
@@ -267,9 +278,7 @@ func TestGetHealthStatusConcurrent(t *testing.T) {
 
 	mc := multiClientFor(urls)
 
-	start := time.Now()
 	status := mc.GetHealthStatus()
-	elapsed := time.Since(start)
 
 	if len(status) != len(urls) {
 		t.Fatalf("got %d statuses, want %d", len(status), len(urls))
@@ -277,10 +286,15 @@ func TestGetHealthStatusConcurrent(t *testing.T) {
 	if status["broken"] {
 		t.Fatal("broken source reported healthy")
 	}
-	if elapsed > time.Duration(float64(delay)*1.8) {
-		t.Fatalf("health fan-out took %s, want near %s", elapsed, delay)
+	for name := range status {
+		if name != "broken" && !status[name] {
+			t.Fatalf("probes did not run concurrently (a serial fan-out stalls on the barrier): %v", status)
+		}
 	}
 
+	// GetHealthyClients probes a second round; every Wait above has returned by
+	// now, so the WaitGroup is safe to re-arm.
+	barrier.Add(probed)
 	healthy := mc.GetHealthyClients()
 	if len(healthy) != 4 {
 		t.Fatalf("got %d healthy clients, want 4: %v", len(healthy), healthy)

--- a/internal/webui/router.go
+++ b/internal/webui/router.go
@@ -49,7 +49,7 @@ func SetupRouter(backendAddress string) *gin.Engine {
 	err = backendClient.Connect()
 	if err != nil {
 		// For now, continue without backend - will show connection errors
-		log.Fatalf("Backend is mandatory on webui %w", err)
+		log.Fatalf("Backend is mandatory on webui: %v", err)
 	}
 
 	// Set backend client for handlers


### PR DESCRIPTION
The multi-Alertmanager fan-outs in `internal/alertmanager/client.go` were plain sequential loops, so a refresh cycle cost `sum(latency)` across sources and an unreachable Alertmanager contributed its full 10s client timeout. `AlertCache.refreshAlerts` is the only caller that matters — it runs off a 10s ticker and coalesces ticks while a refresh is in flight, so one dead source stretched the effective refresh period to ~21s and delayed SSE delivery for the *healthy* sources too.

## Changes

- `snapshotClients()` copies `mc.clients` under `RLock` and releases it before any I/O; a generic `fanOut()` helper runs one goroutine per client with a `sync.WaitGroup` and writes results into per-index slots (no extra mutex). Concurrency is deliberately unbounded — the fleet is the number of configured Alertmanagers.
- Converted `FetchAllAlertsDetailed`, `FetchAllSilences`, `TestAllConnections`, `GetHealthStatus` and `GetHealthyClients`. Return shapes are unchanged.
- Partial-failure contract preserved exactly: a failing source yields an entry in `failedSources` and contributes no alerts, so `refreshAlerts` still leaves its cached alerts untouched instead of mass-resolving them.
- `mc.mutex` is no longer held across any HTTP call, so `UpdateFromConfig` can no longer block for the whole N x timeout window.
- `TestConnection` probes `/api/v2/alerts` with a filter that cannot match (keeps compatibility with Cortex/Mimir, which do not all expose `/api/v2/status`) and drains the body before closing, so the health check stops pulling the full alerts payload and the connection returns to the keep-alive pool.
- Drive-by: `log.Fatalf("... %w", err)` in `internal/webui/router.go` was failing `go vet ./...`; switched to `%v`.

## Tests

New `internal/alertmanager/client_test.go` with `httptest` servers:

- table test asserting the fan-out wall-clock is ~max(latency), not ~sum(latency), for 2 and 5 sources
- one hanging source plus two healthy: healthy alerts returned, dead source in `failedSources`, total time bounded by the single timeout
- `UpdateFromConfig` completes while a fan-out is in flight
- `TestConnection` sends the health filter and reuses the connection on a second probe
- `GetHealthStatus`/`GetHealthyClients` concurrency and correct name to client mapping

`go build -tags "nogui,webui" ./...`, `go vet ./...` and `go test -race ./internal/alertmanager/... ./internal/webui/services/...` all clean (53 tests).

Closes #80

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>