### PR TITLE
feat(devtools): factory TUI human-gate tray

### DIFF
--- a/devtools/factory-tui/factory-tui.py
+++ b/devtools/factory-tui/factory-tui.py
@@ -198,13 +198,20 @@ def ago(sec):
 
 
 def compute_pending(prs, issues, now):
-    """Ball-in-your-court items from raw gh JSON, oldest first. -> [str]"""
+    """Ball-in-your-court items from raw gh JSON, oldest first. -> [str]
+
+    Covers the two gates the loop cannot pass on its own: a PR whose every gate is
+    green (`ready-to-merge`) and an issue parked on `looper:hold`. `rebase:conflict`
+    is deliberately out of scope — the rebaser owns that lane.
+    """
     rows = []
     for p in prs:
         labels = {l["name"] for l in p.get("labels", [])}
+        # `looper:review` is never cleared (it survives merge), so it says nothing
+        # about the gate — `ready-to-merge` is what the agents actually set last.
         if (p.get("isDraft") or p.get("mergeable") != "MERGEABLE"
-                or "qa:passed" not in labels or "qa:failed" in labels
-                or any(l.startswith("looper:") and "review" in l for l in labels)):
+                or "ready-to-merge" not in labels or "qa:failed" in labels
+                or "looper:spec-reviewing" in labels):
             continue
         t = ts(p.get("updatedAt")) or now
         rows.append((t, f"🚢 PR#{p['number']} prête à merger — {ago(now - t)}"))
@@ -212,7 +219,7 @@ def compute_pending(prs, issues, now):
         if not any(l["name"] == "looper:hold" for l in i.get("labels", [])):
             continue
         t = ts(i.get("updatedAt")) or now
-        rows.append((t, f"⛔ #{i['number']} {i.get('title', '')} — attend ton go"))
+        rows.append((t, f"⛔ #{i['number']} {i.get('title', '')[:50]} — attend ton go"))
     return [r for _, r in sorted(rows, key=lambda x: x[0])]
 
 
@@ -300,14 +307,21 @@ def poll_slow():
     except Exception:
         pass
     out = sh(f"gh issue list -R {shlex.quote(REPO)} --state open --json number,title,labels,updatedAt 2>/dev/null", 30)
-    try:
-        iss = open_issues = json.loads(out or "[]")
-        held = sum(1 for i in iss if any(l["name"] == "looper:hold" for l in i["labels"]))
-        agent = sum(1 for i in iss if any(l["name"] == "agent:proposed" for l in i["labels"]))
+    # same rule as the PR query: "" means unreachable, so say so instead of
+    # publishing a hold queue we know is missing rows
+    issues_ok = bool(out.strip())
+    if not issues_ok:
         with LOCK:
-            STATE["issues"] = f"issues: {len(iss)} open · {agent} agents · {held} hold"
-    except Exception:
-        pass
+            STATE["issues"] = "(github injoignable)"
+    else:
+        try:
+            iss = open_issues = json.loads(out)
+            held = sum(1 for i in iss if any(l["name"] == "looper:hold" for l in i["labels"]))
+            agent = sum(1 for i in iss if any(l["name"] == "agent:proposed" for l in i["labels"]))
+            with LOCK:
+                STATE["issues"] = f"issues: {len(iss)} open · {agent} agents · {held} hold"
+        except Exception:
+            issues_ok = False
     since = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - 86400))
     i_out = sh(f"gh issue list -R {shlex.quote(REPO)} --state all --limit 200 "
                f"--search {shlex.quote(f'created:>{since}')} --json labels,createdAt 2>/dev/null", 30)
@@ -321,9 +335,12 @@ def poll_slow():
             score = compute_score(json.loads(i_out), json.loads(p_out), time.time())
         except Exception:
             score = None
+    pending = compute_pending(open_prs, open_issues, time.time())
+    if not issues_ok:
+        pending.append("⛔ hold: (github injoignable)")
     with LOCK:
         STATE["prs"], STATE["score"] = prs, score
-        STATE["pending"] = compute_pending(open_prs, open_issues, time.time())
+        STATE["pending"] = pending
         STATE["events"].extend(events)
 
 
@@ -751,13 +768,16 @@ def selfcheck():
     if compute_score([], [], now) is not None:
         print("FAIL compute_score: empty input should be None")
         fails += 1
-    ready = {"number": 72, "labels": [{"name": "qa:passed"}], "mergeable": "MERGEABLE",
-             "isDraft": False, "updatedAt": "2026-01-01T20:00:00Z"}
+    # a real merge-ready PR still carries `looper:review` — the reviewer agent never
+    # clears it — so the positive fixture has to as well, or the filter is untested
+    ready = {"number": 72, "labels": [{"name": "qa:passed"}, {"name": "looper:review"},
+                                      {"name": "ready-to-merge"}],
+             "mergeable": "MERGEABLE", "isDraft": False, "updatedAt": "2026-01-01T20:00:00Z"}
     pending_prs = [ready,
                    dict(ready, number=73, isDraft=True),
                    dict(ready, number=74, mergeable="CONFLICTING"),
-                   dict(ready, number=75, labels=[{"name": "qa:failed"}]),
-                   dict(ready, number=76, labels=[{"name": "qa:passed"}, {"name": "looper:spec-reviewing"}]),
+                   dict(ready, number=75, labels=ready["labels"] + [{"name": "qa:failed"}]),
+                   dict(ready, number=76, labels=ready["labels"] + [{"name": "looper:spec-reviewing"}]),
                    dict(ready, number=77, labels=[{"name": "qa:passed"}, {"name": "looper:review"}]),
                    dict(ready, number=78, updatedAt="2026-01-01T23:00:00Z")]
     pending_issues = [{"number": 67, "title": "daily reports", "labels": [{"name": "looper:hold"}],
@@ -765,12 +785,18 @@ def selfcheck():
                       {"number": 68, "title": "libre", "labels": [{"name": "agent:proposed"}],
                        "updatedAt": "2025-12-30T00:00:00Z"}]
     pend = compute_pending(pending_prs, pending_issues, now)
+    # #72/#78 are the regression that matters: green gates *and* the sticky review lane
     if pend != ["⛔ #67 daily reports — attend ton go", "🚢 PR#72 prête à merger — 4h",
                 "🚢 PR#78 prête à merger — 1h"]:
         print(f"FAIL compute_pending: {pend}")
         fails += 1
     if compute_pending([], [], now) != []:
         print("FAIL compute_pending: nothing pending should be empty")
+        fails += 1
+    # a long issue title must not eat the "— attend ton go" marker
+    long_row = compute_pending([], [dict(pending_issues[0], title="t" * 200)], now)[0]
+    if not long_row.endswith(" — attend ton go") or len(long_row) > 80:
+        print(f"FAIL compute_pending: long title not bounded: {long_row!r}")
         fails += 1
     with LOCK:
         STATE.update(prs=["PR#0 🧪qa✗"], issues="issues: 0", err="boom", ticker="x" * 300,

--- a/devtools/factory-tui/factory-tui.py
+++ b/devtools/factory-tui/factory-tui.py
@@ -54,7 +54,8 @@ SUMMON_SH = os.path.expanduser("~/.claude-agents/notificator/summon.sh")
 ZOOM_TAIL = 15
 
 STATE = {"loops": [], "svc": {}, "timers": {}, "prs": [], "issues": "", "ticker": "", "err": "",
-         "mail_pending": {}, "intercom": [], "score": None, "events": []}
+         "mail_pending": {}, "intercom": [], "score": None, "events": [], "pending": []}
+PENDING_MAX = 5
 LOCK = threading.Lock()
 
 # one-shot animations, consumed by the render loop (render-side state only)
@@ -179,16 +180,45 @@ def poll_med():
         STATE["events"].extend(events[:6])
 
 
+def ts(s):
+    """GitHub timestamp -> epoch seconds, or None."""
+    try:
+        return calendar.timegm(time.strptime((s or "")[:19], "%Y-%m-%dT%H:%M:%S"))
+    except Exception:
+        return None
+
+
+def ago(sec):
+    """Compact age: 42min · 4h · 3j."""
+    if sec < 3600:
+        return f"{max(0, int(sec // 60))}min"
+    if sec < 86400:
+        return f"{int(sec // 3600)}h"
+    return f"{int(sec // 86400)}j"
+
+
+def compute_pending(prs, issues, now):
+    """Ball-in-your-court items from raw gh JSON, oldest first. -> [str]"""
+    rows = []
+    for p in prs:
+        labels = {l["name"] for l in p.get("labels", [])}
+        if (p.get("isDraft") or p.get("mergeable") != "MERGEABLE"
+                or "qa:passed" not in labels or "qa:failed" in labels
+                or any(l.startswith("looper:") and "review" in l for l in labels)):
+            continue
+        t = ts(p.get("updatedAt")) or now
+        rows.append((t, f"🚢 PR#{p['number']} prête à merger — {ago(now - t)}"))
+    for i in issues:
+        if not any(l["name"] == "looper:hold" for l in i.get("labels", [])):
+            continue
+        t = ts(i.get("updatedAt")) or now
+        rows.append((t, f"⛔ #{i['number']} {i.get('title', '')} — attend ton go"))
+    return [r for _, r in sorted(rows, key=lambda x: x[0])]
+
+
 def compute_score(issues, prs, now):
     """24h team stats from raw gh JSON. -> dict, or None when nothing happened."""
     cutoff = now - 86400
-
-    def ts(s):
-        try:
-            return calendar.timegm(time.strptime((s or "")[:19], "%Y-%m-%dT%H:%M:%S"))
-        except Exception:
-            return None
-
     sc = {"scout": 0, "scout_ok": 0, "roast": 0, "kills": 0,
           "prs": 0, "merged": 0, "qa_ok": 0, "qa_ko": 0}
     events = []
@@ -238,16 +268,17 @@ def compute_score(issues, prs, now):
 
 def poll_slow():
     global PR_PREV
-    prs, events = [], []
-    out = sh(f"gh pr list -R {shlex.quote(REPO)} --state open --json number,title,labels,mergeable 2>/dev/null", 30)
+    prs, events, open_prs, open_issues = [], [], [], []
+    out = sh(f"gh pr list -R {shlex.quote(REPO)} --state open "
+             f"--json number,title,labels,mergeable,isDraft,updatedAt 2>/dev/null", 30)
     if not out.strip():
         # `gh` returns "[]" for zero PRs — an empty string means GitHub is unreachable
         with LOCK:
             STATE["prs"], STATE["issues"] = ["(github injoignable)"], "(github injoignable)"
-            STATE["score"] = "err"
+            STATE["score"], STATE["pending"] = "err", []
         return
     try:
-        data = json.loads(out or "[]")
+        data = open_prs = json.loads(out or "[]")
         for p in data:
             labels = {l["name"] for l in p["labels"]}
             tag = ("💥conflit" if p.get("mergeable") == "CONFLICTING" else
@@ -268,9 +299,9 @@ def poll_slow():
         PR_PREV = now_open
     except Exception:
         pass
-    out = sh(f"gh issue list -R {shlex.quote(REPO)} --state open --json labels 2>/dev/null", 30)
+    out = sh(f"gh issue list -R {shlex.quote(REPO)} --state open --json number,title,labels,updatedAt 2>/dev/null", 30)
     try:
-        iss = json.loads(out or "[]")
+        iss = open_issues = json.loads(out or "[]")
         held = sum(1 for i in iss if any(l["name"] == "looper:hold" for l in i["labels"]))
         agent = sum(1 for i in iss if any(l["name"] == "agent:proposed" for l in i["labels"]))
         with LOCK:
@@ -292,6 +323,7 @@ def poll_slow():
             score = None
     with LOCK:
         STATE["prs"], STATE["score"] = prs, score
+        STATE["pending"] = compute_pending(open_prs, open_issues, time.time())
         STATE["events"].extend(events)
 
 
@@ -511,7 +543,7 @@ def render_frame(tick, width=92, sel=None):
     office_rows = (len(ROSTER) + per_row - 1) // per_row
     with LOCK:
         prs, issues, ticker, err = STATE["prs"], STATE["issues"], STATE["ticker"], STATE["err"]
-        intercom, score = list(STATE["intercom"]), STATE["score"]
+        intercom, score, pending = list(STATE["intercom"]), STATE["score"], list(STATE["pending"])
     if intercom:
         rows.append(("│" + dpad(" ═══ 💬 INTERCOM ", width - 2, fill="═") + "│", 0))
         for msg in intercom:
@@ -528,6 +560,12 @@ def render_frame(tick, width=92, sel=None):
                          + dpad(f"🧪 qa     {score['qa_ok']} ✓ · {score['qa_ko']} ✗", width - 4 - half) + " │", 5))
             star = f"   ⭐ employé du jour: {score['star'].upper()}" if score["star"] else ""
             rows.append(("│ " + dpad("⚡ " + score["spark"] + star, width - 4) + " │", 6))
+    if pending:  # rien en attente → pas de panneau
+        rows.append(("│" + dpad(" ═══ 🙋 EN ATTENTE DE TOI ", width - 2, fill="═") + "│", 0))
+        for row in pending[:PENDING_MAX]:
+            rows.append(("│ " + dpad(row, width - 4) + " │", 6))
+        if len(pending) > PENDING_MAX:
+            rows.append(("│ " + dpad(f"… +{len(pending) - PENDING_MAX} autres", width - 4) + " │", 5))
     rows.append(("│" + dpad(" ═══ 📌 TABLEAU DU MUR ", width - 2, fill="═") + "│", 0))
     board_pos = (width // 2, len(rows) - 1)
     rows.append(("│ " + dpad("  ".join(prs) or "aucune PR ouverte — tout est mergé 🎉", width - 4) + " │", 5))
@@ -713,8 +751,30 @@ def selfcheck():
     if compute_score([], [], now) is not None:
         print("FAIL compute_score: empty input should be None")
         fails += 1
+    ready = {"number": 72, "labels": [{"name": "qa:passed"}], "mergeable": "MERGEABLE",
+             "isDraft": False, "updatedAt": "2026-01-01T20:00:00Z"}
+    pending_prs = [ready,
+                   dict(ready, number=73, isDraft=True),
+                   dict(ready, number=74, mergeable="CONFLICTING"),
+                   dict(ready, number=75, labels=[{"name": "qa:failed"}]),
+                   dict(ready, number=76, labels=[{"name": "qa:passed"}, {"name": "looper:spec-reviewing"}]),
+                   dict(ready, number=77, labels=[{"name": "qa:passed"}, {"name": "looper:review"}]),
+                   dict(ready, number=78, updatedAt="2026-01-01T23:00:00Z")]
+    pending_issues = [{"number": 67, "title": "daily reports", "labels": [{"name": "looper:hold"}],
+                       "updatedAt": "2025-12-30T00:00:00Z"},
+                      {"number": 68, "title": "libre", "labels": [{"name": "agent:proposed"}],
+                       "updatedAt": "2025-12-30T00:00:00Z"}]
+    pend = compute_pending(pending_prs, pending_issues, now)
+    if pend != ["⛔ #67 daily reports — attend ton go", "🚢 PR#72 prête à merger — 4h",
+                "🚢 PR#78 prête à merger — 1h"]:
+        print(f"FAIL compute_pending: {pend}")
+        fails += 1
+    if compute_pending([], [], now) != []:
+        print("FAIL compute_pending: nothing pending should be empty")
+        fails += 1
     with LOCK:
         STATE.update(prs=["PR#0 🧪qa✗"], issues="issues: 0", err="boom", ticker="x" * 300,
+                     pending=pend + [f"⛔ #{n} titre très long ✨ {'é' * 60} — attend ton go" for n in range(80, 85)],
                      mail_pending={"scout": 2}, intercom=["roast → scout: amend #1 📬", "scout → roast: done"],
                      events=[{"kind": "mail", "frm": "scout", "to": "worker"},
                              {"kind": "mail", "frm": "inconnu", "to": "qa"},
@@ -727,6 +787,16 @@ def selfcheck():
                 if dwidth(line) != w:
                     print(f"FAIL row {dwidth(line)} cols (want {w}): {line!r}")
                     fails += 1
+    # pending tray: capped with an overflow marker, absent when the queue is empty
+    body = "\n".join(l for l, _ in render_frame(1, 92))
+    if "🙋 EN ATTENTE DE TOI" not in body or "… +3 autres" not in body:
+        print("FAIL pending panel: header or overflow marker missing")
+        fails += 1
+    with LOCK:
+        STATE["pending"] = []
+    if "EN ATTENTE" in "\n".join(l for l, _ in render_frame(1, 92)):
+        print("FAIL pending panel rendered with nothing pending")
+        fails += 1
     # control room: selected border and zoom panel keep every row at exact width
     for line, _ in render_frame(3, 92, sel=5):
         if dwidth(line) != 92:


### PR DESCRIPTION
## What

New `🙋 EN ATTENTE DE TOI` panel in the factory TUI, between `🏆 SCOREBOARD` and `📌 TABLEAU DU MUR`, listing everything the autonomous loop is blocked on *you* for:

- `🚢 PR#72 prête à merger — 4h` — open PRs that are non-draft, `MERGEABLE`, `qa:passed`, without `qa:failed` and without a `looper:*review*` label (those are still in the reviewer agent's lane).
- `⛔ #67 daily reports — attend ton go` — open issues labelled `looper:hold`.

Rows are sorted oldest-first from `updatedAt`, capped at 5 with a `… +N autres` marker, and the whole panel is hidden when nothing is pending (same convention as the scoreboard).

## Why

`allowAutoMerge=false` and `looper:hold` are the two human gates in the loop. The board printed `PR#84 ✅qa` right next to `PR#85 🧪qa✗` with nothing marking the first as ball-in-your-court, and held issues were just a digit in the `issues: … hold` line. The operator is the throughput limiter and could not see their own queue.

## How

No new `gh` invocations — the two existing `poll_slow()` queries just request more fields (`isDraft,updatedAt` on PRs; `number,title,updatedAt` on issues). `sh(` call count in `poll_slow` is unchanged (5 before, 5 after). `ts()` is hoisted out of `compute_score` so `compute_pending()` reuses the same parsing. Still stdlib-only and read-only.

## Validation

- `python3 devtools/factory-tui/factory-tui.py --check` → `selfcheck: OK`, with new cases for the PR filter matrix (draft / conflicting / `qa:failed` / `looper:spec-reviewing` / `looper:review` all excluded), oldest-first ordering, age formatting, the overflow marker, and frame-width invariants at 92 and 60 cols with a pending set injected.
- `python3 devtools/factory-tui/factory-tui.py --once` → exit 0; against live data the panel shows the 3 `looper:hold` issues matching the `3 hold` counter, and correctly omits `PR#84` (green but still carrying `looper:review`).

Closes #75

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>