### PR TITLE
perf(webui): serve bulk alert status from the live cache only

### DIFF
--- a/internal/webui/handlers/dashboard_handlers.go
+++ b/internal/webui/handlers/dashboard_handlers.go
@@ -1376,7 +1376,9 @@ func GetBulkAlertStatus(c *gin.Context) {
 	statuses := make(map[string]map[string]interface{})
 
 	for _, fingerprint := range request.Fingerprints {
-		alert := alertCache.GetAlertByFingerprint(fingerprint)
+		// Live cache only: the callers are resolved fingerprints, so a backend
+		// fallback would be a gRPC round trip per row for data we never report.
+		alert := alertCache.GetLiveAlert(fingerprint)
 		if alert != nil {
 			// Alert found in live cache
 			statuses[fingerprint] = map[string]interface{}{

--- a/internal/webui/services/alert_cache.go
+++ b/internal/webui/services/alert_cache.go
@@ -773,6 +773,25 @@ func (ac *AlertCache) GetAlertByFingerprint(fingerprint string) *webuimodels.Das
 	return nil
 }
 
+// GetLiveAlert looks the fingerprint up in the live cache only, never falling
+// back to the backend's resolved_alerts table. Callers that only need "is this
+// alert firing/silenced right now" must use this: GetAlert costs a gRPC round
+// trip plus a JSONB point query per miss.
+func (ac *AlertCache) GetLiveAlert(fingerprint string) *webuimodels.DashboardAlert {
+	ac.mu.RLock()
+	defer ac.mu.RUnlock()
+
+	alert, exists := ac.alerts[fingerprint]
+	if !exists {
+		return nil
+	}
+
+	// Copy under the lock: the background refresher keeps mutating the cached
+	// struct after RUnlock.
+	alertCopy := *alert
+	return &alertCopy
+}
+
 func (ac *AlertCache) GetAlertColors(fingerprint, userID string) *AlertColorResult {
 	alert := ac.GetAlertByFingerprint(fingerprint)
 	if alert == nil {

--- a/internal/webui/services/alert_cache_test.go
+++ b/internal/webui/services/alert_cache_test.go
@@ -1058,3 +1058,31 @@ func TestAlertCache_ResolvedCountCacheAndFallback(t *testing.T) {
 		t.Errorf("stale, no backend: got %d, want 42", got)
 	}
 }
+
+func TestAlertCache_GetLiveAlert(t *testing.T) {
+	cache := NewAlertCache(nil, nil, 90, 10*time.Second)
+
+	const fingerprint = "live-fingerprint"
+	cache.UpdateAlert(&webuimodels.DashboardAlert{
+		Fingerprint: fingerprint,
+		Status:      webuimodels.AlertStatus{State: "suppressed", SilencedBy: []string{"silence-1"}},
+	})
+
+	if got := cache.GetLiveAlert("missing"); got != nil {
+		t.Errorf("GetLiveAlert should return nil for a fingerprint absent from the live cache, got %+v", got)
+	}
+
+	live := cache.GetLiveAlert(fingerprint)
+	if live == nil {
+		t.Fatal("GetLiveAlert should return the cached alert")
+	}
+	if live.Status.State != "suppressed" || len(live.Status.SilencedBy) != 1 {
+		t.Errorf("unexpected live status: %+v", live.Status)
+	}
+
+	// Snapshot semantics: writing through the result must not touch the cache.
+	live.Status.State = "firing"
+	if again := cache.GetLiveAlert(fingerprint); again.Status.State != "suppressed" {
+		t.Errorf("GetLiveAlert returned a cache-resident pointer: State = %q, want \"suppressed\"", again.Status.State)
+	}
+}


### PR DESCRIPTION
## Problem

`GetBulkAlertStatus` resolved each fingerprint via `alertCache.GetAlertByFingerprint`, which falls back to the backend's `GetResolvedAlert` RPC when the alert is not in the live cache. Its only consumer is the resolved-alerts view, which POSTs one fingerprint per row of the page it just loaded — by definition resolved, so virtually every lookup missed the live cache.

Result: up to 100 **serial** webui→backend gRPC calls per resolved-view page load or pagination click, each triggering a `SELECT *` point query on `resolved_alerts` that deserializes the `alert_data` / `comments` / `acknowledgments` JSONB blobs.

None of that data was observable: the handler only reports `state` / `in_cache` / `is_resolved`, and the client treats a backend-resolved alert (`in_cache: true, state: "resolved"`) exactly like a cache miss (`in_cache: false`) — both pass the `state !== 'suppressed'` filter.

## Changes

- `internal/webui/services/alert_cache.go`: add `GetLiveAlert(fingerprint)` — a read-locked map lookup with no backend fallback, returning a snapshot copy like the other accessors (the background refresher mutates cache-resident structs).
- `internal/webui/handlers/dashboard_handlers.go`: `GetBulkAlertStatus` uses `GetLiveAlert` instead of `GetAlertByFingerprint`.
- `internal/webui/services/alert_cache_test.go`: cover the hit/miss paths and the snapshot semantics.

Other `GetAlertByFingerprint` callers are unchanged — they genuinely need the resolved fallback.

## Behavior

No frontend change; the templ files are untouched, so no regeneration.

- Fingerprints in the live cache still report live `state` / `silenced_by` / `inhibited_by`, so silenced-while-refiring alerts stay filtered out of the resolved view.
- Fingerprints absent from the live cache return `in_cache: false, state: "resolved"` — the same shape as before, already handled by the client.
- ~100 in-memory map lookups replace ~100 serial RPCs + DB point queries per page.

## Validation

- `go build ./...` passes.
- `go test ./internal/webui/services/ -run TestAlertCache -count=1` passes.

Closes #91

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>