### PR TITLE
fix(webui): keep acknowledgement state in SSE alert updates

### DIFF
--- a/internal/webui/services/alert_cache.go
+++ b/internal/webui/services/alert_cache.go
@@ -40,6 +40,16 @@ type alertFetcher interface {
 	FetchAllAlertsDetailed() ([]alertmanager.AlertWithSource, map[string]error)
 }
 
+// collabLoader abstracts the backend calls that feed collaboration state into the
+// cache, so tests can exercise the dedup guards in loadAcknowledgmentsEfficiently
+// and loadCommentCountsEfficiently without a live backend.
+// *client.BackendClient satisfies it.
+type collabLoader interface {
+	IsConnected() bool
+	GetAllAcknowledgedAlerts(alertKeys []string) (map[string]*alertpb.Acknowledgment, error)
+	GetCommentCountsBatch(fingerprints []string) (map[string]int, error)
+}
+
 // maxBackendWorkers bounds concurrent backend calls spawned by a refresh cycle,
 // so a large diff cannot stampede the backend with thousands of gRPC calls.
 const maxBackendWorkers = 8
@@ -56,6 +66,7 @@ type AlertCache struct {
 	userHiddenAlerts   map[string]map[string]bool             // userID -> fingerprint -> hidden
 	alertmanagerClient alertFetcher
 	backendClient      *client.BackendClient
+	collabClient       collabLoader // same object as backendClient, narrowed so tests can fake it
 	colorService       *ColorService
 	backendSem         chan struct{} // semaphore bounding refresh-triggered backend calls
 
@@ -108,11 +119,19 @@ func NewAlertCache(amClient *alertmanager.MultiClient, backendClient *client.Bac
 		fetcher = amClient
 	}
 
+	// Same care for the collaboration seam: a typed-nil in the interface would
+	// defeat the nil check in loadBackendData.
+	var collab collabLoader
+	if backendClient != nil {
+		collab = backendClient
+	}
+
 	return &AlertCache{
 		alerts:                make(map[string]*webuimodels.DashboardAlert),
 		userHiddenAlerts:      make(map[string]map[string]bool),
 		alertmanagerClient:    fetcher,
 		backendClient:         backendClient,
+		collabClient:          collab,
 		colorService:          NewColorService(backendClient),
 		cachedColors:          make(map[string]map[string]*AlertColorResult),
 		backendSem:            make(chan struct{}, maxBackendWorkers),
@@ -220,7 +239,11 @@ func (ac *AlertCache) refreshAlerts() {
 		if existingAlert, exists := ac.alerts[fingerprint]; !exists {
 			ac.alerts[fingerprint] = dashAlert
 			ac.newAlerts = append(ac.newAlerts, fingerprint)
-			newAlertsForSSE = append(newAlertsForSSE, dashAlert)
+			// Snapshot, never the cache-resident pointer: the backend loaders and
+			// MutateAlert write to it under ac.mu while the SSE handler serialises
+			// the payload holding no lock.
+			alertCopy := *dashAlert
+			newAlertsForSSE = append(newAlertsForSSE, &alertCopy)
 
 			// Capture alert fired event for statistics
 			ac.runBounded(func() {
@@ -293,12 +316,10 @@ func (ac *AlertCache) refreshAlerts() {
 
 	log.Printf("Alert cache refresh complete: %d active alerts, %d newly resolved", activeCount, resolvedCount)
 
-	ac.loadBackendData()
-
-	// Refresh color cache for all active users after alerts are updated
-	go ac.RefreshAllCachedColors()
-
-	// Notify SSE subscribers if there are any changes
+	// Emit the poll diff before anything else can write to the cache. These are
+	// snapshots taken under ac.mu, so a collaboration write landing right after the
+	// unlock above must not be allowed to push its fresher payload first and then be
+	// overwritten by this older one — the dashboard replaces alert objects wholesale.
 	if len(newAlertsForSSE) > 0 || len(updatedAlertsForSSE) > 0 || len(removedFingerprints) > 0 {
 		update := &webuimodels.DashboardIncrementalUpdate{
 			NewAlerts:      newAlertsForSSE,
@@ -308,6 +329,11 @@ func (ac *AlertCache) refreshAlerts() {
 		}
 		ac.notifySubscribers(update)
 	}
+
+	ac.loadBackendData()
+
+	// Refresh color cache for all active users after alerts are updated
+	go ac.RefreshAllCachedColors()
 }
 
 func (ac *AlertCache) convertToDashboardAlert(alert models.Alert, source string) *webuimodels.DashboardAlert {
@@ -496,11 +522,11 @@ func (ac *AlertCache) MutateAlert(fingerprint string, fn func(*webuimodels.Dashb
 
 func (ac *AlertCache) loadBackendData() {
 	log.Printf("loadBackendData called - checking backend connection...")
-	if ac.backendClient == nil {
+	if ac.collabClient == nil {
 		log.Printf("Backend client is nil - skipping acknowledgment loading")
 		return
 	}
-	if !ac.backendClient.IsConnected() {
+	if !ac.collabClient.IsConnected() {
 		log.Printf("Backend client not connected - skipping acknowledgment loading")
 		return
 	}
@@ -528,7 +554,7 @@ func (ac *AlertCache) loadAcknowledgmentsEfficiently() {
 	}
 
 	// Step 2: call gRPC with NO lock held
-	acknowledgedAlerts, err := ac.backendClient.GetAllAcknowledgedAlerts(fingerprints)
+	acknowledgedAlerts, err := ac.collabClient.GetAllAcknowledgedAlerts(fingerprints)
 	if err != nil {
 		log.Printf("Failed to load acknowledged alerts from backend: %v", err)
 		return
@@ -624,7 +650,7 @@ func (ac *AlertCache) loadCommentCountsEfficiently() {
 	}
 
 	// Step 2: call gRPC with NO lock held
-	counts, err := ac.backendClient.GetCommentCountsBatch(fingerprints)
+	counts, err := ac.collabClient.GetCommentCountsBatch(fingerprints)
 	if err != nil {
 		log.Printf("Failed to load comment counts batch: %v", err)
 		// Reset all comment counts to 0 on error

--- a/internal/webui/services/alert_cache.go
+++ b/internal/webui/services/alert_cache.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"maps"
 	"strings"
 	"sync"
 	"time"
@@ -231,11 +232,19 @@ func (ac *AlertCache) refreshAlerts() {
 			})
 
 		} else {
-			// Check if alert changed before updating
-			if ac.hasAlertChanged(existingAlert, dashAlert) {
-				updatedAlertsForSSE = append(updatedAlertsForSSE, dashAlert)
+			// Only compare what a poll can actually tell us: the fresh alert has no
+			// collaboration state, so comparing it against the cache would report a
+			// change on every cycle for every acknowledged or commented alert.
+			changed := ac.hasPolledStateChanged(existingAlert, dashAlert)
+			ac.updateExistingAlert(existingAlert, dashAlert, changed)
+
+			if changed {
+				// Push the merged cache entry, not the stripped poll result, so the
+				// SSE payload keeps acknowledgement and comment state. Shallow copy
+				// for the same reason GetAllAlerts snapshots.
+				alertCopy := *existingAlert
+				updatedAlertsForSSE = append(updatedAlertsForSSE, &alertCopy)
 			}
-			ac.updateExistingAlert(existingAlert, dashAlert)
 		}
 	}
 
@@ -370,9 +379,8 @@ func (ac *AlertCache) convertToDashboardAlert(alert models.Alert, source string)
 // 		!old.EndsAt.Equal(new.EndsAt)
 // }
 
-func (ac *AlertCache) updateExistingAlert(existing, new *webuimodels.DashboardAlert) {
-	// Check if alert has meaningfully changed before updating UpdatedAt
-	if ac.hasAlertChanged(existing, new) {
+func (ac *AlertCache) updateExistingAlert(existing, new *webuimodels.DashboardAlert, changed bool) {
+	if changed {
 		existing.UpdatedAt = time.Now()
 	}
 	// Note: UpdatedAt is NOT updated if alert hasn't changed
@@ -383,6 +391,21 @@ func (ac *AlertCache) updateExistingAlert(existing, new *webuimodels.DashboardAl
 	existing.IsResolved = new.IsResolved
 
 	existing.Annotations = new.Annotations
+	// Summary is derived from the annotations, so it has to follow them; leaving
+	// it stale would make hasPolledStateChanged report a change forever.
+	existing.Summary = new.Summary
+}
+
+// hasPolledStateChanged compares only the fields an Alertmanager poll actually
+// populates. Acknowledgements and comment counts arrive through MutateAlert and
+// loadBackendData, never through a poll, so comparing them against a freshly
+// converted alert would always report a change.
+// ponytail: EndsAt is deliberately excluded — Alertmanager keeps pushing it
+// forward for firing alerts, which would mark every alert changed every cycle.
+func (ac *AlertCache) hasPolledStateChanged(existing, new *webuimodels.DashboardAlert) bool {
+	return existing.Status.State != new.Status.State ||
+		existing.Summary != new.Summary ||
+		!maps.Equal(existing.Annotations, new.Annotations)
 }
 
 // hasAlertChanged compares two alerts to determine if there are meaningful changes
@@ -448,15 +471,26 @@ func (ac *AlertCache) UpdateAlert(alert *webuimodels.DashboardAlert) {
 // fingerprint is not in the live cache. This is the only supported way to write
 // to a cached alert — the read accessors return snapshots, so writes through
 // their return values never reach the cache.
+//
+// A mutation is a real change by definition (acknowledgements, comments,
+// manual resolution), so it stamps UpdatedAt and pushes the merged alert to SSE
+// subscribers. The poll cycle cannot detect these — the alert it builds from
+// Alertmanager carries no collaboration state at all.
 func (ac *AlertCache) MutateAlert(fingerprint string, fn func(*webuimodels.DashboardAlert)) bool {
 	ac.mu.Lock()
-	defer ac.mu.Unlock()
 
 	alert, exists := ac.alerts[fingerprint]
 	if !exists {
+		ac.mu.Unlock()
 		return false
 	}
+	now := time.Now()
 	fn(alert)
+	alert.UpdatedAt = now
+	alertCopy := *alert
+	ac.mu.Unlock()
+
+	ac.notifyAlertsUpdated([]*webuimodels.DashboardAlert{&alertCopy}, now)
 	return true
 }
 
@@ -519,28 +553,57 @@ func (ac *AlertCache) loadAcknowledgmentsEfficiently() {
 // The snapshot is point-in-time: an acknowledgment written locally (the
 // acknowledge handler's MutateAlert) after the map was built is cleared here and
 // reappears on the next refresh.
+//
+// Only real transitions are pushed to SSE subscribers: a steady acknowledgment
+// re-observed on every refresh must not generate an update, or every poll cycle
+// would repaint the dashboard.
 func (ac *AlertCache) applyAcknowledgments(acknowledgedAlerts map[string]*alertpb.Acknowledgment) {
-	ac.mu.Lock()
-	defer ac.mu.Unlock()
+	now := time.Now()
+	var changed []*webuimodels.DashboardAlert
 
+	ac.mu.Lock()
 	for fingerprint, alert := range ac.alerts {
 		if acknowledgment, exists := acknowledgedAlerts[fingerprint]; exists {
+			acknowledgedAt := acknowledgment.CreatedAt.AsTime()
+			if alert.IsAcknowledged &&
+				alert.AcknowledgedBy == acknowledgment.Username &&
+				alert.AcknowledgedAt.Equal(acknowledgedAt) &&
+				alert.AcknowledgeReason == acknowledgment.Reason {
+				continue
+			}
+
 			alert.IsAcknowledged = true
 			alert.AcknowledgedBy = acknowledgment.Username
-			alert.AcknowledgedAt = acknowledgment.CreatedAt.AsTime()
+			alert.AcknowledgedAt = acknowledgedAt
 			alert.AcknowledgeReason = acknowledgment.Reason
+			alert.UpdatedAt = now
+
+			alertCopy := *alert
+			changed = append(changed, &alertCopy)
 
 			// Note: Comment counts are loaded separately by loadCommentCountsEfficiently()
 			// Note: We don't capture statistics here because this is loading historical
 			// acknowledgments. Statistics should only be captured when alerts are
 			// acknowledged in real-time to avoid negative MTTR calculations.
 		} else {
+			if !alert.IsAcknowledged && alert.AcknowledgedBy == "" &&
+				alert.AcknowledgedAt.IsZero() && alert.AcknowledgeReason == "" {
+				continue
+			}
+
 			alert.IsAcknowledged = false
 			alert.AcknowledgedBy = ""
 			alert.AcknowledgedAt = time.Time{}
 			alert.AcknowledgeReason = ""
+			alert.UpdatedAt = now
+
+			alertCopy := *alert
+			changed = append(changed, &alertCopy)
 		}
 	}
+	ac.mu.Unlock()
+
+	ac.notifyAlertsUpdated(changed, now)
 }
 
 func (ac *AlertCache) loadCommentCountsEfficiently() {
@@ -575,19 +638,29 @@ func (ac *AlertCache) loadCommentCountsEfficiently() {
 
 	// Step 3: write results back under Lock
 	alertsWithComments := 0
+	now := time.Now()
+	var changed []*webuimodels.DashboardAlert
+
 	ac.mu.Lock()
 	for fingerprint, alert := range ac.alerts {
-		if count, exists := counts[fingerprint]; exists {
-			alert.CommentCount = count
-			if count > 0 {
-				alertsWithComments++
-			}
-		} else {
-			alert.CommentCount = 0
+		count := counts[fingerprint] // missing fingerprint means no comments
+		if count > 0 {
+			alertsWithComments++
 		}
+		if alert.CommentCount == count {
+			continue
+		}
+
+		alert.CommentCount = count
+		alert.UpdatedAt = now
+
+		alertCopy := *alert
+		changed = append(changed, &alertCopy)
 	}
 	totalAlerts := len(ac.alerts)
 	ac.mu.Unlock()
+
+	ac.notifyAlertsUpdated(changed, now)
 
 	log.Printf("Successfully loaded comment counts for %d alerts (%d with comments) using batch query", totalAlerts, alertsWithComments)
 }
@@ -1122,6 +1195,18 @@ func (ac *AlertCache) notifySubscribers(update *webuimodels.DashboardIncremental
 			log.Printf("SSE subscriber channel full, skipping update")
 		}
 	}
+}
+
+// notifyAlertsUpdated pushes already-snapshotted alerts to SSE subscribers.
+// Callers must pass copies, never cache-resident pointers.
+func (ac *AlertCache) notifyAlertsUpdated(alerts []*webuimodels.DashboardAlert, at time.Time) {
+	if len(alerts) == 0 {
+		return
+	}
+	ac.notifySubscribers(&webuimodels.DashboardIncrementalUpdate{
+		UpdatedAlerts:  alerts,
+		LastUpdateTime: at.Unix(),
+	})
 }
 
 // GetSubscriberCount returns the current number of SSE subscribers.

--- a/internal/webui/services/alert_cache_test.go
+++ b/internal/webui/services/alert_cache_test.go
@@ -825,6 +825,99 @@ func (f *fakeAlertFetcher) FetchAllAlertsDetailed() ([]alertmanager.AlertWithSou
 	return f.alerts, f.fetchErrors
 }
 
+// TestAlertCache_RefreshKeepsAcknowledgementState covers the SSE regression where
+// a refresh cycle compared the cache against a collaboration-free poll result and
+// pushed that stripped alert to browsers, flipping acked alerts back to un-acked.
+func TestAlertCache_RefreshKeepsAcknowledgementState(t *testing.T) {
+	amAlert := alertmanager.AlertWithSource{
+		Alert: models.Alert{
+			Labels:      map[string]string{"alertname": "HighMemoryUsage"},
+			Annotations: map[string]string{"summary": "Memory is high"},
+			Status:      models.AlertStatus{State: "firing"},
+			StartsAt:    time.Now().Add(-time.Hour),
+		},
+		Source: "prod",
+	}
+
+	cache := NewAlertCache(nil, nil, 90, 10*time.Second)
+	cache.alertmanagerClient = &fakeAlertFetcher{alerts: []alertmanager.AlertWithSource{amAlert}}
+	cache.refreshAlerts()
+
+	updates := cache.Subscribe()
+	defer cache.Unsubscribe(updates)
+
+	fingerprint := cache.convertToDashboardAlert(amAlert.Alert, amAlert.Source).Fingerprint
+	acknowledgedAt := time.Now().Add(-time.Minute)
+	if !cache.MutateAlert(fingerprint, func(a *webuimodels.DashboardAlert) {
+		a.IsAcknowledged = true
+		a.AcknowledgedBy = "alice"
+		a.AcknowledgedAt = acknowledgedAt
+		a.CommentCount = 2
+	}) {
+		t.Fatal("alert should be cached after the seeding refresh")
+	}
+
+	updatedAt := func() time.Time {
+		alert, ok := cache.GetAlert(fingerprint)
+		if !ok {
+			t.Fatal("alert disappeared from the cache")
+		}
+		return alert.UpdatedAt
+	}
+	beforeRefresh := updatedAt()
+
+	// The acknowledgement itself is what has to reach browsers, with real state.
+	select {
+	case update := <-updates:
+		if len(update.UpdatedAlerts) != 1 || !update.UpdatedAlerts[0].IsAcknowledged {
+			t.Fatalf("acknowledgement should be pushed over SSE with ack state, got %+v", update.UpdatedAlerts)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("acknowledging an alert should push an SSE update")
+	}
+
+	// Three cycles with an unchanged Alertmanager payload: nothing should move.
+	for i := 0; i < 3; i++ {
+		cache.refreshAlerts()
+
+		select {
+		case update := <-updates:
+			t.Fatalf("cycle %d: unchanged alert should not be pushed over SSE, got %d updated alerts", i, len(update.UpdatedAlerts))
+		default:
+		}
+
+		cached, _ := cache.GetAlert(fingerprint)
+		if !cached.IsAcknowledged || cached.AcknowledgedBy != "alice" || cached.CommentCount != 2 {
+			t.Fatalf("cycle %d: collaboration state lost: %+v", i, cached)
+		}
+		if !cached.UpdatedAt.Equal(beforeRefresh) {
+			t.Fatalf("cycle %d: UpdatedAt advanced without a real change", i)
+		}
+	}
+
+	// A real Alertmanager-side change must still be pushed, with ack state intact.
+	changed := amAlert
+	changed.Alert.Annotations = map[string]string{"summary": "Memory is critical"}
+	cache.alertmanagerClient = &fakeAlertFetcher{alerts: []alertmanager.AlertWithSource{changed}}
+	cache.refreshAlerts()
+
+	select {
+	case update := <-updates:
+		if len(update.UpdatedAlerts) != 1 {
+			t.Fatalf("expected 1 updated alert, got %d", len(update.UpdatedAlerts))
+		}
+		pushed := update.UpdatedAlerts[0]
+		if !pushed.IsAcknowledged || pushed.AcknowledgedBy != "alice" || pushed.CommentCount != 2 {
+			t.Errorf("SSE payload lost collaboration state: %+v", pushed)
+		}
+		if pushed.Summary != "Memory is critical" {
+			t.Errorf("SSE payload should carry the new summary, got %q", pushed.Summary)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("a changed alert should be pushed over SSE")
+	}
+}
+
 func TestAlertCache_RefreshWithPartialFetchFailure(t *testing.T) {
 	newAlert := func(name, source string) alertmanager.AlertWithSource {
 		return alertmanager.AlertWithSource{

--- a/internal/webui/services/alert_cache_test.go
+++ b/internal/webui/services/alert_cache_test.go
@@ -918,6 +918,190 @@ func TestAlertCache_RefreshKeepsAcknowledgementState(t *testing.T) {
 	}
 }
 
+// fakeCollabLoader drives the backend side of the collaboration loaders, which
+// are the only path left for backend-side ack and comment changes to reach
+// browsers now that hasPolledStateChanged ignores those fields.
+type fakeCollabLoader struct {
+	acks      map[string]*alertpb.Acknowledgment
+	acksErr   error
+	counts    map[string]int
+	countsErr error
+}
+
+func (f *fakeCollabLoader) IsConnected() bool { return true }
+
+func (f *fakeCollabLoader) GetAllAcknowledgedAlerts([]string) (map[string]*alertpb.Acknowledgment, error) {
+	return f.acks, f.acksErr
+}
+
+func (f *fakeCollabLoader) GetCommentCountsBatch([]string) (map[string]int, error) {
+	return f.counts, f.countsErr
+}
+
+// seedCachedAlert returns a cache holding exactly one firing alert with the
+// collaboration seam wired to loader, plus that alert's fingerprint and a
+// subscriber with no update pending.
+func seedCachedAlert(t *testing.T, loader collabLoader) (*AlertCache, string, chan *webuimodels.DashboardIncrementalUpdate) {
+	t.Helper()
+
+	amAlert := alertmanager.AlertWithSource{
+		Alert: models.Alert{
+			Labels:      map[string]string{"alertname": "HighMemoryUsage"},
+			Annotations: map[string]string{"summary": "Memory is high"},
+			Status:      models.AlertStatus{State: "firing"},
+			StartsAt:    time.Now().Add(-time.Hour),
+		},
+		Source: "prod",
+	}
+
+	cache := NewAlertCache(nil, nil, 90, 10*time.Second)
+	cache.alertmanagerClient = &fakeAlertFetcher{alerts: []alertmanager.AlertWithSource{amAlert}}
+	// collabClient is still nil here, so the seeding refresh spawns no loader.
+	cache.refreshAlerts()
+	cache.collabClient = loader
+
+	updates := cache.Subscribe()
+	t.Cleanup(func() { cache.Unsubscribe(updates) })
+
+	return cache, cache.convertToDashboardAlert(amAlert.Alert, amAlert.Source).Fingerprint, updates
+}
+
+func nextUpdate(t *testing.T, updates chan *webuimodels.DashboardIncrementalUpdate) *webuimodels.DashboardIncrementalUpdate {
+	t.Helper()
+	select {
+	case update := <-updates:
+		return update
+	case <-time.After(time.Second):
+		t.Fatal("expected an SSE update")
+		return nil
+	}
+}
+
+// expectNoUpdate asserts nothing is queued. The loaders notify synchronously, so
+// a non-blocking read is enough.
+func expectNoUpdate(t *testing.T, updates chan *webuimodels.DashboardIncrementalUpdate) {
+	t.Helper()
+	select {
+	case update := <-updates:
+		t.Fatalf("unexpected SSE update: %+v", update.UpdatedAlerts)
+	default:
+	}
+}
+
+func TestAlertCache_LoadAcknowledgmentsPushesOnlyRealChanges(t *testing.T) {
+	createdAt := time.Now().Add(-time.Minute).Truncate(time.Second)
+	firstAck := func() *alertpb.Acknowledgment {
+		return &alertpb.Acknowledgment{
+			Username:  "alice",
+			Reason:    "investigating",
+			CreatedAt: timestamppb.New(createdAt),
+		}
+	}
+
+	tests := []struct {
+		name       string
+		second     *alertpb.Acknowledgment
+		wantPushed bool
+	}{
+		{
+			name:       "identical acknowledgement is pushed once",
+			second:     firstAck(),
+			wantPushed: false,
+		},
+		{
+			name:       "changed reason is pushed",
+			second:     &alertpb.Acknowledgment{Username: "alice", Reason: "escalated", CreatedAt: timestamppb.New(createdAt)},
+			wantPushed: true,
+		},
+		{
+			name:       "changed createdAt is pushed",
+			second:     &alertpb.Acknowledgment{Username: "alice", Reason: "investigating", CreatedAt: timestamppb.New(createdAt.Add(time.Second))},
+			wantPushed: true,
+		},
+		{
+			name:       "re-acknowledgement by another user is pushed",
+			second:     &alertpb.Acknowledgment{Username: "bob", Reason: "investigating", CreatedAt: timestamppb.New(createdAt)},
+			wantPushed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			loader := &fakeCollabLoader{}
+			cache, fingerprint, updates := seedCachedAlert(t, loader)
+
+			loader.acks = map[string]*alertpb.Acknowledgment{fingerprint: firstAck()}
+			cache.loadAcknowledgmentsEfficiently()
+
+			first := nextUpdate(t, updates).UpdatedAlerts
+			if len(first) != 1 || !first[0].IsAcknowledged || first[0].AcknowledgedBy != "alice" {
+				t.Fatalf("first load should push the acknowledgement, got %+v", first)
+			}
+
+			loader.acks = map[string]*alertpb.Acknowledgment{fingerprint: tt.second}
+			cache.loadAcknowledgmentsEfficiently()
+
+			if !tt.wantPushed {
+				expectNoUpdate(t, updates)
+				return
+			}
+
+			second := nextUpdate(t, updates).UpdatedAlerts
+			if len(second) != 1 {
+				t.Fatalf("expected 1 updated alert, got %d", len(second))
+			}
+			pushed := second[0]
+			if pushed.AcknowledgedBy != tt.second.Username ||
+				pushed.AcknowledgeReason != tt.second.Reason ||
+				!pushed.AcknowledgedAt.Equal(tt.second.CreatedAt.AsTime()) {
+				t.Errorf("pushed payload does not carry the new acknowledgement: %+v", pushed)
+			}
+		})
+	}
+}
+
+func TestAlertCache_LoadCommentCountsPushesOnlyRealChanges(t *testing.T) {
+	loader := &fakeCollabLoader{}
+	cache, fingerprint, updates := seedCachedAlert(t, loader)
+
+	if !cache.MutateAlert(fingerprint, func(a *webuimodels.DashboardAlert) {
+		a.IsAcknowledged = true
+		a.AcknowledgedBy = "alice"
+		a.AcknowledgedAt = time.Now().Add(-time.Minute)
+	}) {
+		t.Fatal("alert should be cached after the seeding refresh")
+	}
+	nextUpdate(t, updates) // the acknowledgement push itself
+
+	loader.counts = map[string]int{fingerprint: 2}
+	cache.loadCommentCountsEfficiently()
+
+	pushed := nextUpdate(t, updates).UpdatedAlerts
+	if len(pushed) != 1 || pushed[0].CommentCount != 2 {
+		t.Fatalf("a new comment count should be pushed, got %+v", pushed)
+	}
+	if !pushed[0].IsAcknowledged || pushed[0].AcknowledgedBy != "alice" {
+		t.Errorf("comment-count push lost acknowledgement state: %+v", pushed[0])
+	}
+
+	// Same count next cycle: nothing on the wire.
+	cache.loadCommentCountsEfficiently()
+	expectNoUpdate(t, updates)
+
+	// The error branch zeroes every cached count and notifies nobody.
+	loader.countsErr = errors.New("backend down")
+	cache.loadCommentCountsEfficiently()
+	expectNoUpdate(t, updates)
+
+	cached, ok := cache.GetAlert(fingerprint)
+	if !ok {
+		t.Fatal("alert disappeared from the cache")
+	}
+	if cached.CommentCount != 0 {
+		t.Errorf("comment counts should be zeroed when the batch query fails, got %d", cached.CommentCount)
+	}
+}
+
 func TestAlertCache_RefreshWithPartialFetchFailure(t *testing.T) {
 	newAlert := func(name, source string) alertmanager.AlertWithSource {
 		return alertmanager.AlertWithSource{


### PR DESCRIPTION
## Problem

`convertToDashboardAlert` builds an alert from what Alertmanager knows, so `IsAcknowledged`, `AcknowledgedBy` and `CommentCount` are always zero on it. `hasAlertChanged` compared exactly those fields against the cache entry, so every acknowledged or commented alert was "changed" on every poll — and the object queued for SSE was that stripped alert. Open dashboards lost the acknowledged badge and comment count once per refresh cycle, and `UpdatedAt` advanced forever on precisely the alerts someone was working on.

## Changes

`internal/webui/services/alert_cache.go`

- `hasPolledStateChanged` compares only what a poll populates: `Status.State`, `Summary`, `Annotations`. `EndsAt` is deliberately excluded — Alertmanager keeps pushing it forward for firing alerts, which would mark everything changed every cycle. `hasAlertChanged` is unchanged and still used by `UpdateAlert`, which does write collaboration fields.
- The refresh merge branch queues a shallow copy of the merged cache entry (same approach as `GetAllAlerts`) instead of `dashAlert`, so the SSE payload carries real ack and comment state.
- `updateExistingAlert` now copies `Summary` too. It never did; leaving it stale would make the new comparison report a change forever once a summary changed.
- Acknowledgements no longer reach browsers through the poll diff, so they are emitted where they happen: `MutateAlert` stamps `UpdatedAt` and pushes the merged alert to subscribers, and `loadAcknowledgmentsEfficiently` / `loadCommentCountsEfficiently` push only the alerts whose backend state actually moved rather than rewriting every alert every cycle.

No template or JS changes — the browser side was already rendering whatever the payload said.

## Validation

`TestAlertCache_RefreshKeepsAcknowledgementState` seeds an acknowledged alert, asserts the acknowledgement itself is pushed over SSE with `isAcknowledged: true`, then runs three refresh cycles with an unchanged Alertmanager payload and asserts no SSE update fires, the collaboration state survives and `UpdatedAt` does not move. A final cycle with a changed annotation asserts the push happens and carries both the new summary and the ack state.

`go build ./...`, `go vet ./internal/webui/...`, `go test ./... -count=1` and `go test ./internal/webui/... -race` all pass.

Closes #102

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>