### PR TITLE
fix(backend): a re-firing alert no longer inherits the previous incident's acknowledgement

### DIFF
--- a/internal/backend/database/gorm_db.go
+++ b/internal/backend/database/gorm_db.go
@@ -2,11 +2,13 @@ package database
 
 import (
 	"crypto/rand"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"gorm.io/driver/postgres"
@@ -513,6 +515,42 @@ func (gdb *GormDB) GetAllAcknowledgedAlerts(alertKeys []string) (map[string]mode
 	return result, nil
 }
 
+// isEmptyAcknowledgmentSnapshot reports whether the caller supplied no usable
+// acknowledgment history — either nothing at all, because its fetch failed, or
+// an empty JSON payload.
+func isEmptyAcknowledgmentSnapshot(acknowledgments []byte) bool {
+	switch strings.TrimSpace(string(acknowledgments)) {
+	case "", "null", "[]", "{}":
+		return true
+	}
+	return false
+}
+
+// snapshotAcknowledgments reads the live acknowledgments of an alert through tx,
+// shaped like GetAcknowledgments so both snapshot sources serialize the same.
+// Returns nil when the alert has none.
+func snapshotAcknowledgments(tx *gorm.DB, fingerprint string) ([]byte, error) {
+	var acks []models.AcknowledgmentWithUser
+	if err := tx.Table("acknowledgments").
+		Select("acknowledgments.*, users.username").
+		Joins("JOIN users ON users.id = acknowledgments.user_id").
+		Where("acknowledgments.alert_key = ?", fingerprint).
+		Order("acknowledgments.created_at DESC").
+		Find(&acks).Error; err != nil {
+		return nil, fmt.Errorf("failed to read acknowledgments for resolved alert: %w", err)
+	}
+
+	if len(acks) == 0 {
+		return nil, nil
+	}
+
+	snapshot, err := json.Marshal(acks)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize acknowledgments for resolved alert: %w", err)
+	}
+	return snapshot, nil
+}
+
 func (gdb *GormDB) CreateResolvedAlert(fingerprint, source string, alertData, comments, acknowledgments []byte, ttlHours int) (*models.ResolvedAlert, error) {
 	now := time.Now()
 	resolvedAlert := &models.ResolvedAlert{
@@ -525,11 +563,23 @@ func (gdb *GormDB) CreateResolvedAlert(fingerprint, source string, alertData, co
 		Source:          source,
 	}
 
-	// The acknowledgment belongs to the firing that just ended and is already
-	// snapshotted in the row above. Leaving the live rows behind would silently
-	// re-acknowledge the next firing of the same labels, which share a
-	// fingerprint, and hide it from the classic dashboard.
+	// The acknowledgment belongs to the firing that just ended. Leaving the live
+	// rows behind would silently re-acknowledge the next firing of the same
+	// labels, which share a fingerprint, and hide it from the classic dashboard.
+	//
+	// The caller's snapshot is best-effort — it comes from a separate RPC that
+	// may have failed — so the rows are read here when it is missing. Snapshot
+	// and delete then share one transaction and the history cannot be lost.
 	err := gdb.db.Transaction(func(tx *gorm.DB) error {
+		if isEmptyAcknowledgmentSnapshot(acknowledgments) {
+			snapshot, err := snapshotAcknowledgments(tx, fingerprint)
+			if err != nil {
+				return err
+			}
+			if snapshot != nil {
+				resolvedAlert.Acknowledgments = models.JSONB(snapshot)
+			}
+		}
 		if err := tx.Create(resolvedAlert).Error; err != nil {
 			return fmt.Errorf("failed to create resolved alert: %w", err)
 		}

--- a/internal/backend/database/gorm_db.go
+++ b/internal/backend/database/gorm_db.go
@@ -525,8 +525,21 @@ func (gdb *GormDB) CreateResolvedAlert(fingerprint, source string, alertData, co
 		Source:          source,
 	}
 
-	if err := gdb.db.Create(resolvedAlert).Error; err != nil {
-		return nil, fmt.Errorf("failed to create resolved alert: %w", err)
+	// The acknowledgment belongs to the firing that just ended and is already
+	// snapshotted in the row above. Leaving the live rows behind would silently
+	// re-acknowledge the next firing of the same labels, which share a
+	// fingerprint, and hide it from the classic dashboard.
+	err := gdb.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(resolvedAlert).Error; err != nil {
+			return fmt.Errorf("failed to create resolved alert: %w", err)
+		}
+		if err := tx.Where("alert_key = ?", fingerprint).Delete(&models.Acknowledgment{}).Error; err != nil {
+			return fmt.Errorf("failed to clear acknowledgments for resolved alert: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return resolvedAlert, nil

--- a/internal/backend/database/gorm_db_test.go
+++ b/internal/backend/database/gorm_db_test.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -125,8 +126,46 @@ func TestCreateResolvedAlertClearsAcknowledgments(t *testing.T) {
 	}
 }
 
-// TestCleanupResolvedAcknowledgments covers the one-off migration that drops
-// acknowledgment rows orphaned by resolutions that happened before the fix.
+// TestCreateResolvedAlertSnapshotsAcknowledgmentsWhenCallerHasNone pins the
+// other half of that lifecycle: the caller builds its snapshot with a separate,
+// best-effort RPC, so when that fetch fails the rows must still be recorded
+// before the same transaction deletes them.
+func TestCreateResolvedAlertSnapshotsAcknowledgmentsWhenCallerHasNone(t *testing.T) {
+	for _, payload := range [][]byte{nil, []byte(`[]`), []byte(`null`)} {
+		gdb := newTestDB(t)
+
+		alice := models.User{ID: "u1", Username: "alice", Email: "alice@example.com"}
+		if err := gdb.db.Create(&alice).Error; err != nil {
+			t.Fatalf("create user: %v", err)
+		}
+		ack := models.Acknowledgment{ID: "a1", AlertKey: "resolved-key", UserID: alice.ID, Reason: "on it"}
+		if err := gdb.db.Create(&ack).Error; err != nil {
+			t.Fatalf("create ack: %v", err)
+		}
+
+		resolved, err := gdb.CreateResolvedAlert("resolved-key", "prod", []byte(`{}`), nil, payload, 24)
+		if err != nil {
+			t.Fatalf("CreateResolvedAlert(%q): %v", payload, err)
+		}
+
+		var snapshot []models.AcknowledgmentWithUser
+		if err := json.Unmarshal([]byte(resolved.Acknowledgments), &snapshot); err != nil {
+			t.Fatalf("snapshot for payload %q is not readable acknowledgment history: %v (%q)", payload, err, resolved.Acknowledgments)
+		}
+		if len(snapshot) != 1 || snapshot[0].Username != "alice" || snapshot[0].Reason != "on it" {
+			t.Errorf("payload %q: acknowledgment history lost, got %+v", payload, snapshot)
+		}
+
+		if live, _ := gdb.GetAcknowledgments("resolved-key"); len(live) != 0 {
+			t.Errorf("payload %q: live acknowledgments should still be cleared, got %d", payload, len(live))
+		}
+	}
+}
+
+// TestCleanupResolvedAcknowledgments covers the startup migration that drops
+// acknowledgment rows orphaned by resolutions that happened before the fix. It
+// re-runs on every boot, so it must keep the acknowledgment of an alert that
+// resolved and then fired again inside the resolved-alert retention window.
 func TestCleanupResolvedAcknowledgments(t *testing.T) {
 	gdb := newTestDB(t)
 
@@ -135,9 +174,13 @@ func TestCleanupResolvedAcknowledgments(t *testing.T) {
 		t.Fatalf("create user: %v", err)
 	}
 
+	now := time.Now()
 	acks := []models.Acknowledgment{
-		{ID: "a1", AlertKey: "orphan-key", UserID: alice.ID, Reason: "stale"},
-		{ID: "a2", AlertKey: "firing-key", UserID: alice.ID, Reason: "current"},
+		// Acknowledged before the resolution: belongs to the firing that ended.
+		{ID: "a1", AlertKey: "orphan-key", UserID: alice.ID, Reason: "stale", CreatedAt: now.Add(-2 * time.Hour)},
+		{ID: "a2", AlertKey: "firing-key", UserID: alice.ID, Reason: "current", CreatedAt: now.Add(-2 * time.Hour)},
+		// Acknowledged after the resolution: belongs to the firing that is live now.
+		{ID: "a3", AlertKey: "refired-key", UserID: alice.ID, Reason: "on the new one", CreatedAt: now.Add(-5 * time.Minute)},
 	}
 	for i := range acks {
 		if err := gdb.db.Create(&acks[i]).Error; err != nil {
@@ -145,15 +188,14 @@ func TestCleanupResolvedAcknowledgments(t *testing.T) {
 		}
 	}
 
-	now := time.Now()
-	if err := gdb.db.Create(&models.ResolvedAlert{
-		Fingerprint: "orphan-key",
-		AlertData:   models.JSONB(`{}`),
-		ResolvedAt:  now.Add(-time.Hour),
-		ExpiresAt:   now.Add(23 * time.Hour),
-		Source:      "prod",
-	}).Error; err != nil {
-		t.Fatalf("create resolved alert: %v", err)
+	resolved := []models.ResolvedAlert{
+		{Fingerprint: "orphan-key", AlertData: models.JSONB(`{}`), ResolvedAt: now.Add(-time.Hour), ExpiresAt: now.Add(23 * time.Hour), Source: "prod"},
+		{Fingerprint: "refired-key", AlertData: models.JSONB(`{}`), ResolvedAt: now.Add(-time.Hour), ExpiresAt: now.Add(23 * time.Hour), Source: "prod"},
+	}
+	for i := range resolved {
+		if err := gdb.db.Create(&resolved[i]).Error; err != nil {
+			t.Fatalf("create resolved alert: %v", err)
+		}
 	}
 
 	if err := gdb.cleanupResolvedAcknowledgments(); err != nil {
@@ -165,5 +207,8 @@ func TestCleanupResolvedAcknowledgments(t *testing.T) {
 	}
 	if firing, _ := gdb.GetAcknowledgments("firing-key"); len(firing) != 1 {
 		t.Errorf("acknowledgment of a still-firing alert must survive, got %d", len(firing))
+	}
+	if refired, _ := gdb.GetAcknowledgments("refired-key"); len(refired) != 1 {
+		t.Errorf("acknowledgment created after the resolution belongs to the live firing, got %d", len(refired))
 	}
 }

--- a/internal/backend/database/gorm_db_test.go
+++ b/internal/backend/database/gorm_db_test.go
@@ -19,7 +19,7 @@ func newTestDB(t *testing.T) *GormDB {
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
-	if err := db.AutoMigrate(&models.User{}, &models.Acknowledgment{}); err != nil {
+	if err := db.AutoMigrate(&models.User{}, &models.Acknowledgment{}, &models.ResolvedAlert{}); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
 	return &GormDB{db: db, dbType: "sqlite"}
@@ -77,5 +77,93 @@ func TestAcknowledgmentCompositeIndexExists(t *testing.T) {
 	gdb := newTestDB(t)
 	if !gdb.db.Migrator().HasIndex(&models.Acknowledgment{}, "idx_acknowledgments_alert_key_created_at") {
 		t.Fatal("composite index idx_acknowledgments_alert_key_created_at missing after migration")
+	}
+}
+
+// TestCreateResolvedAlertClearsAcknowledgments pins the ack lifecycle to a
+// firing: once the alert resolves, the live rows go away so the next firing of
+// the same labels — same fingerprint — is not acknowledged on someone's behalf.
+func TestCreateResolvedAlertClearsAcknowledgments(t *testing.T) {
+	gdb := newTestDB(t)
+
+	alice := models.User{ID: "u1", Username: "alice", Email: "alice@example.com"}
+	if err := gdb.db.Create(&alice).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	acks := []models.Acknowledgment{
+		{ID: "a1", AlertKey: "resolved-key", UserID: alice.ID, Reason: "on it"},
+		{ID: "a2", AlertKey: "other-key", UserID: alice.ID, Reason: "unrelated"},
+	}
+	for i := range acks {
+		if err := gdb.db.Create(&acks[i]).Error; err != nil {
+			t.Fatalf("create ack: %v", err)
+		}
+	}
+
+	snapshot := []byte(`[{"username":"alice","reason":"on it"}]`)
+	resolved, err := gdb.CreateResolvedAlert("resolved-key", "prod", []byte(`{}`), nil, snapshot, 24)
+	if err != nil {
+		t.Fatalf("CreateResolvedAlert: %v", err)
+	}
+
+	// History survives on the resolved snapshot.
+	if string(resolved.Acknowledgments) != string(snapshot) {
+		t.Errorf("resolved alert should keep the acknowledgment snapshot, got %q", resolved.Acknowledgments)
+	}
+
+	live, err := gdb.GetAcknowledgments("resolved-key")
+	if err != nil {
+		t.Fatalf("GetAcknowledgments: %v", err)
+	}
+	if len(live) != 0 {
+		t.Errorf("live acknowledgments should be cleared on resolution, got %d", len(live))
+	}
+
+	if others, _ := gdb.GetAcknowledgments("other-key"); len(others) != 1 {
+		t.Errorf("acknowledgments of other alerts must be untouched, got %d", len(others))
+	}
+}
+
+// TestCleanupResolvedAcknowledgments covers the one-off migration that drops
+// acknowledgment rows orphaned by resolutions that happened before the fix.
+func TestCleanupResolvedAcknowledgments(t *testing.T) {
+	gdb := newTestDB(t)
+
+	alice := models.User{ID: "u1", Username: "alice", Email: "alice@example.com"}
+	if err := gdb.db.Create(&alice).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	acks := []models.Acknowledgment{
+		{ID: "a1", AlertKey: "orphan-key", UserID: alice.ID, Reason: "stale"},
+		{ID: "a2", AlertKey: "firing-key", UserID: alice.ID, Reason: "current"},
+	}
+	for i := range acks {
+		if err := gdb.db.Create(&acks[i]).Error; err != nil {
+			t.Fatalf("create ack: %v", err)
+		}
+	}
+
+	now := time.Now()
+	if err := gdb.db.Create(&models.ResolvedAlert{
+		Fingerprint: "orphan-key",
+		AlertData:   models.JSONB(`{}`),
+		ResolvedAt:  now.Add(-time.Hour),
+		ExpiresAt:   now.Add(23 * time.Hour),
+		Source:      "prod",
+	}).Error; err != nil {
+		t.Fatalf("create resolved alert: %v", err)
+	}
+
+	if err := gdb.cleanupResolvedAcknowledgments(); err != nil {
+		t.Fatalf("cleanupResolvedAcknowledgments: %v", err)
+	}
+
+	if orphans, _ := gdb.GetAcknowledgments("orphan-key"); len(orphans) != 0 {
+		t.Errorf("orphaned acknowledgments should be deleted, got %d", len(orphans))
+	}
+	if firing, _ := gdb.GetAcknowledgments("firing-key"); len(firing) != 1 {
+		t.Errorf("acknowledgment of a still-firing alert must survive, got %d", len(firing))
 	}
 }

--- a/internal/backend/database/migrate.go
+++ b/internal/backend/database/migrate.go
@@ -352,10 +352,15 @@ func (gdb *GormDB) backfillFixTimeSeconds() error {
 	return nil
 }
 
-// cleanupResolvedAcknowledgments drops acknowledgments whose alert already
-// resolved. Until CreateResolvedAlert started clearing them, these rows survived
-// the resolution and re-acknowledged the next firing of the same labels, which
-// share a fingerprint.
+// cleanupResolvedAcknowledgments drops acknowledgments left behind by a
+// resolution. Until CreateResolvedAlert started clearing them, these rows
+// survived the resolution and re-acknowledged the next firing of the same
+// labels, which share a fingerprint.
+//
+// This runs on every backend start, not once, so the predicate has to tell a
+// stale row from a live one: only an acknowledgment created *before* the
+// resolution belongs to the firing that ended. An alert that resolves, fires
+// again and gets acknowledged keeps that acknowledgment across restarts.
 //
 // ponytail: keyed on resolved_alerts, so it only reaches orphans whose resolved
 // snapshot has not expired yet (retention default 24h). Older orphans are
@@ -369,7 +374,11 @@ func (gdb *GormDB) cleanupResolvedAcknowledgments() error {
 
 	result := gdb.db.Exec(`
 		DELETE FROM acknowledgments
-		WHERE alert_key IN (SELECT fingerprint FROM resolved_alerts)
+		WHERE EXISTS (
+			SELECT 1 FROM resolved_alerts r
+			WHERE r.fingerprint = acknowledgments.alert_key
+			  AND r.resolved_at > acknowledgments.created_at
+		)
 	`)
 	if result.Error != nil {
 		return fmt.Errorf("failed to delete acknowledgments of resolved alerts: %w", result.Error)

--- a/internal/backend/database/migrate.go
+++ b/internal/backend/database/migrate.go
@@ -29,6 +29,11 @@ func (gdb *GormDB) RunCustomMigrations() error {
 		return fmt.Errorf("failed to backfill fix_time_seconds: %w", err)
 	}
 
+	// Drop acknowledgments left behind by alerts that already resolved
+	if err := gdb.cleanupResolvedAcknowledgments(); err != nil {
+		return fmt.Errorf("failed to cleanup resolved acknowledgments: %w", err)
+	}
+
 	log.Println("✅ Custom migrations completed")
 	return nil
 }
@@ -342,6 +347,38 @@ func (gdb *GormDB) backfillFixTimeSeconds() error {
 		log.Printf("✅ Backfilled fix_time_seconds for %d alert records", result.RowsAffected)
 	} else {
 		log.Println("ℹ️  No alerts need fix_time_seconds backfill")
+	}
+
+	return nil
+}
+
+// cleanupResolvedAcknowledgments drops acknowledgments whose alert already
+// resolved. Until CreateResolvedAlert started clearing them, these rows survived
+// the resolution and re-acknowledged the next firing of the same labels, which
+// share a fingerprint.
+//
+// ponytail: keyed on resolved_alerts, so it only reaches orphans whose resolved
+// snapshot has not expired yet (retention default 24h). Older orphans are
+// indistinguishable from a live acknowledgment and must be un-acknowledged from
+// the UI.
+func (gdb *GormDB) cleanupResolvedAcknowledgments() error {
+	if !gdb.db.Migrator().HasTable("acknowledgments") || !gdb.db.Migrator().HasTable("resolved_alerts") {
+		log.Println("ℹ️  acknowledgments or resolved_alerts table doesn't exist yet, skipping cleanup")
+		return nil
+	}
+
+	result := gdb.db.Exec(`
+		DELETE FROM acknowledgments
+		WHERE alert_key IN (SELECT fingerprint FROM resolved_alerts)
+	`)
+	if result.Error != nil {
+		return fmt.Errorf("failed to delete acknowledgments of resolved alerts: %w", result.Error)
+	}
+
+	if result.RowsAffected > 0 {
+		log.Printf("✅ Cleaned up %d acknowledgments left behind by resolved alerts", result.RowsAffected)
+	} else {
+		log.Println("ℹ️  No acknowledgments left behind by resolved alerts")
 	}
 
 	return nil

--- a/internal/backend/services/acknowledged_alerts_test.go
+++ b/internal/backend/services/acknowledged_alerts_test.go
@@ -19,7 +19,7 @@ func TestGetAllAcknowledgedAlerts_SurfacesDatabaseError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create test database: %v", err)
 	}
-	svc := NewAlertServiceGorm(db)
+	svc := NewAlertServiceGorm(db, &config.AdminConfig{})
 
 	resp, err := svc.GetAllAcknowledgedAlerts(context.Background(), &alertpb.GetAllAcknowledgedAlertsRequest{
 		AlertKeys: []string{"fp-1"},

--- a/internal/backend/services/acknowledged_alerts_test.go
+++ b/internal/backend/services/acknowledged_alerts_test.go
@@ -1,0 +1,33 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"notificator/config"
+	"notificator/internal/backend/database"
+	alertpb "notificator/internal/backend/proto/alert"
+)
+
+// TestGetAllAcknowledgedAlerts_SurfacesDatabaseError guards the webui cache:
+// applyAcknowledgments clears every fingerprint missing from the response, so an
+// empty map returned with a nil error would un-acknowledge the whole dashboard
+// on a statement timeout or a failover. The failure has to reach the caller.
+func TestGetAllAcknowledgedAlerts_SurfacesDatabaseError(t *testing.T) {
+	// No AutoMigrate: the acknowledgments table is missing, so the query fails.
+	db, err := database.NewGormDB("sqlite", config.DatabaseConfig{SQLitePath: t.TempDir() + "/test.db"})
+	if err != nil {
+		t.Fatalf("failed to create test database: %v", err)
+	}
+	svc := NewAlertServiceGorm(db)
+
+	resp, err := svc.GetAllAcknowledgedAlerts(context.Background(), &alertpb.GetAllAcknowledgedAlertsRequest{
+		AlertKeys: []string{"fp-1"},
+	})
+	if err == nil {
+		t.Fatalf("expected a database failure to surface as an error, got response %+v", resp)
+	}
+	if resp != nil {
+		t.Errorf("expected no response alongside the error, got %+v", resp)
+	}
+}

--- a/internal/backend/services/services.go
+++ b/internal/backend/services/services.go
@@ -14,6 +14,8 @@ import (
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/oauth2"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"notificator/config"
@@ -716,15 +718,17 @@ func (s *AlertServiceGorm) GetAcknowledgments(ctx context.Context, req *alertpb.
 	}, nil
 }
 
-// GetAllAcknowledgedAlerts implements the GetAllAcknowledgedAlerts RPC method
+// GetAllAcknowledgedAlerts implements the GetAllAcknowledgedAlerts RPC method.
+//
+// Callers treat the response as an authoritative snapshot and clear the
+// acknowledgment of every fingerprint missing from it, so a database failure
+// must surface as an error rather than as an empty map — an empty map would
+// un-acknowledge the whole dashboard on a statement timeout or a failover.
 func (s *AlertServiceGorm) GetAllAcknowledgedAlerts(ctx context.Context, req *alertpb.GetAllAcknowledgedAlertsRequest) (*alertpb.GetAllAcknowledgedAlertsResponse, error) {
 	acknowledgedAlerts, err := s.db.GetAllAcknowledgedAlerts(req.AlertKeys)
 	if err != nil {
 		log.Printf("Error getting all acknowledged alerts: %v", err)
-		return &alertpb.GetAllAcknowledgedAlertsResponse{
-			AcknowledgedAlerts: make(map[string]*alertpb.Acknowledgment),
-			Count:              0,
-		}, nil
+		return nil, status.Errorf(codes.Internal, "failed to load acknowledged alerts: %v", err)
 	}
 
 	// Convert to protobuf format

--- a/internal/webui/services/alert_cache.go
+++ b/internal/webui/services/alert_cache.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"notificator/internal/alertmanager"
+	alertpb "notificator/internal/backend/proto/alert"
 	"notificator/internal/models"
 	"notificator/internal/webui/client"
 	webuimodels "notificator/internal/webui/models"
@@ -501,9 +502,20 @@ func (ac *AlertCache) loadAcknowledgmentsEfficiently() {
 
 	log.Printf("Received %d acknowledged alerts from backend", len(acknowledgedAlerts))
 
+	ac.applyAcknowledgments(acknowledgedAlerts)
+
+	log.Printf("Successfully updated %d alerts with acknowledgment data", len(acknowledgedAlerts))
+}
+
+// applyAcknowledgments makes the cache mirror the backend exactly: alerts the
+// backend no longer reports as acknowledged are cleared, so a re-firing alert
+// does not latch onto the previous incident's acknowledgment.
+func (ac *AlertCache) applyAcknowledgments(acknowledgedAlerts map[string]*alertpb.Acknowledgment) {
 	ac.mu.Lock()
-	for fingerprint, acknowledgment := range acknowledgedAlerts {
-		if alert, exists := ac.alerts[fingerprint]; exists {
+	defer ac.mu.Unlock()
+
+	for fingerprint, alert := range ac.alerts {
+		if acknowledgment, exists := acknowledgedAlerts[fingerprint]; exists {
 			alert.IsAcknowledged = true
 			alert.AcknowledgedBy = acknowledgment.Username
 			alert.AcknowledgedAt = acknowledgment.CreatedAt.AsTime()
@@ -513,11 +525,13 @@ func (ac *AlertCache) loadAcknowledgmentsEfficiently() {
 			// Note: We don't capture statistics here because this is loading historical
 			// acknowledgments. Statistics should only be captured when alerts are
 			// acknowledged in real-time to avoid negative MTTR calculations.
+		} else {
+			alert.IsAcknowledged = false
+			alert.AcknowledgedBy = ""
+			alert.AcknowledgedAt = time.Time{}
+			alert.AcknowledgeReason = ""
 		}
 	}
-	ac.mu.Unlock()
-
-	log.Printf("Successfully updated %d alerts with acknowledgment data", len(acknowledgedAlerts))
 }
 
 func (ac *AlertCache) loadCommentCountsEfficiently() {

--- a/internal/webui/services/alert_cache.go
+++ b/internal/webui/services/alert_cache.go
@@ -510,6 +510,15 @@ func (ac *AlertCache) loadAcknowledgmentsEfficiently() {
 // applyAcknowledgments makes the cache mirror the backend exactly: alerts the
 // backend no longer reports as acknowledged are cleared, so a re-firing alert
 // does not latch onto the previous incident's acknowledgment.
+//
+// acknowledgedAlerts must be a snapshot the backend actually produced — never an
+// empty map standing in for a failed fetch, which would un-acknowledge the whole
+// dashboard. GetAllAcknowledgedAlerts returns a gRPC error on a database failure
+// for that reason, and callers must return before reaching here.
+//
+// The snapshot is point-in-time: an acknowledgment written locally (the
+// acknowledge handler's MutateAlert) after the map was built is cleared here and
+// reappears on the next refresh.
 func (ac *AlertCache) applyAcknowledgments(acknowledgedAlerts map[string]*alertpb.Acknowledgment) {
 	ac.mu.Lock()
 	defer ac.mu.Unlock()

--- a/internal/webui/services/alert_cache_test.go
+++ b/internal/webui/services/alert_cache_test.go
@@ -6,7 +6,10 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	"notificator/internal/alertmanager"
+	alertpb "notificator/internal/backend/proto/alert"
 	"notificator/internal/models"
 	webuimodels "notificator/internal/webui/models"
 )
@@ -1084,5 +1087,71 @@ func TestAlertCache_GetLiveAlert(t *testing.T) {
 	live.Status.State = "firing"
 	if again := cache.GetLiveAlert(fingerprint); again.Status.State != "suppressed" {
 		t.Errorf("GetLiveAlert returned a cache-resident pointer: State = %q, want \"suppressed\"", again.Status.State)
+	}
+}
+
+// TestAlertCache_AcknowledgmentDoesNotSurviveResolution walks the resolve →
+// re-fire cycle: an acknowledged alert resolves, the backend drops the live ack
+// row along with it, and the next firing of the same labels — same fingerprint —
+// must come back un-acknowledged instead of vanishing from the classic dashboard.
+func TestAlertCache_AcknowledgmentDoesNotSurviveResolution(t *testing.T) {
+	firing := alertmanager.AlertWithSource{
+		Alert: models.Alert{
+			Labels:   map[string]string{"alertname": "HighMemoryUsage", "instance": "db-1"},
+			Status:   models.AlertStatus{State: "firing"},
+			StartsAt: time.Now().Add(-time.Hour),
+		},
+		Source: "prod",
+	}
+
+	cache := NewAlertCache(nil, nil, 90, 10*time.Second)
+	fingerprint := cache.convertToDashboardAlert(firing.Alert, firing.Source).Fingerprint
+
+	fetcher := &fakeAlertFetcher{alerts: []alertmanager.AlertWithSource{firing}}
+	cache.alertmanagerClient = fetcher
+	cache.refreshAlerts()
+
+	acked := map[string]*alertpb.Acknowledgment{
+		fingerprint: {
+			Username:  "alice",
+			Reason:    "looking into it",
+			CreatedAt: timestamppb.New(time.Now().Add(-30 * time.Minute)),
+		},
+	}
+	cache.applyAcknowledgments(acked)
+
+	alert, ok := cache.GetAlert(fingerprint)
+	if !ok || !alert.IsAcknowledged || alert.AcknowledgedBy != "alice" {
+		t.Fatalf("alert should be acknowledged by alice, got %+v", alert)
+	}
+
+	// A still-firing acknowledged alert stays acknowledged across refresh cycles.
+	cache.refreshAlerts()
+	cache.applyAcknowledgments(acked)
+	if alert, _ := cache.GetAlert(fingerprint); !alert.IsAcknowledged {
+		t.Error("a still-firing acknowledged alert must stay acknowledged across refreshes")
+	}
+
+	// The alert resolves and leaves the cache.
+	fetcher.alerts = nil
+	cache.refreshAlerts()
+	if _, ok := cache.GetAlert(fingerprint); ok {
+		t.Fatal("alert should leave the cache once its source stops reporting it")
+	}
+
+	// It fires again with identical labels; the backend no longer holds the ack.
+	fetcher.alerts = []alertmanager.AlertWithSource{firing}
+	cache.refreshAlerts()
+	cache.applyAcknowledgments(map[string]*alertpb.Acknowledgment{})
+
+	refired, ok := cache.GetAlert(fingerprint)
+	if !ok {
+		t.Fatal("re-firing alert should be back in the cache")
+	}
+	if refired.IsAcknowledged {
+		t.Errorf("re-firing alert inherited the previous incident's acknowledgment: by=%q at=%v", refired.AcknowledgedBy, refired.AcknowledgedAt)
+	}
+	if refired.AcknowledgedBy != "" || !refired.AcknowledgedAt.IsZero() || refired.AcknowledgeReason != "" {
+		t.Errorf("acknowledgment fields not cleared: %+v", refired)
 	}
 }

--- a/openwiki/backend.md
+++ b/openwiki/backend.md
@@ -45,11 +45,20 @@ SQL is guarded by `IsSQLite()` / `IsPostgreSQL()`.
 
 `AutoMigrate()` runs `RunCustomMigrations()` **first** (`database/migrate.go`: dedupe
 `alert_statistics` before adding a unique index, add `column_configs` to `filter_presets`,
-create `user_column_preferences`, backfill `fix_time_seconds`), then GORM `AutoMigrate` over
+create `user_column_preferences`, backfill `fix_time_seconds`, drop acknowledgments of already
+resolved alerts), then GORM `AutoMigrate` over
 ~20 models: users, sessions, comments, acknowledgments, resolved_alerts, notification prefs,
 hidden alerts/rules, filter presets, the full OAuth table set, Sentry config, alert statistics
 + aggregates, statistics views, annotation-button configs. On Postgres it additionally creates
 GIN indexes on `alert_statistics.metadata` (best-effort — failure only warns).
+
+**Acknowledgments are scoped to a firing.** `alert_key` is the label-only fingerprint, so two
+incidents of the same alert share it. `CreateResolvedAlert` therefore deletes the live
+`acknowledgments` rows in the same transaction that snapshots them into `resolved_alerts` —
+otherwise the next firing inherits the previous incident's ack and disappears from the classic
+dashboard. The `cleanupResolvedAcknowledgments` migration drops rows orphaned before that fix,
+but only for resolutions still present in `resolved_alerts` (TTL 24h by default); older orphans
+must be un-acknowledged from the UI.
 
 **Two independent expiry mechanisms** (don't confuse them when debugging "my data vanished"):
 

--- a/openwiki/backend.md
+++ b/openwiki/backend.md
@@ -45,8 +45,8 @@ SQL is guarded by `IsSQLite()` / `IsPostgreSQL()`.
 
 `AutoMigrate()` runs `RunCustomMigrations()` **first** (`database/migrate.go`: dedupe
 `alert_statistics` before adding a unique index, add `column_configs` to `filter_presets`,
-create `user_column_preferences`, backfill `fix_time_seconds`, drop acknowledgments of already
-resolved alerts), then GORM `AutoMigrate` over
+create `user_column_preferences`, backfill `fix_time_seconds`, drop acknowledgments that predate
+a resolution), then GORM `AutoMigrate` over
 ~20 models: users, sessions, comments, acknowledgments, resolved_alerts, notification prefs,
 hidden alerts/rules, filter presets, the full OAuth table set, Sentry config, alert statistics
 + aggregates, statistics views, annotation-button configs. On Postgres it additionally creates
@@ -56,9 +56,16 @@ GIN indexes on `alert_statistics.metadata` (best-effort — failure only warns).
 incidents of the same alert share it. `CreateResolvedAlert` therefore deletes the live
 `acknowledgments` rows in the same transaction that snapshots them into `resolved_alerts` —
 otherwise the next firing inherits the previous incident's ack and disappears from the classic
-dashboard. The `cleanupResolvedAcknowledgments` migration drops rows orphaned before that fix,
-but only for resolutions still present in `resolved_alerts` (TTL 24h by default); older orphans
-must be un-acknowledged from the UI.
+dashboard. The snapshot is taken inside that transaction: when the caller sends no
+acknowledgments payload, `CreateResolvedAlert` reads the rows through `tx` itself, so a failed
+snapshot fetch upstream cannot turn the delete into history loss.
+
+`cleanupResolvedAcknowledgments` sweeps rows orphaned by resolutions that predate that fix. It
+is **not** one-shot — it runs on every backend start — so it only deletes acknowledgments whose
+`created_at` is older than the matching `resolved_alerts.resolved_at`; an alert that resolved,
+fired again and was acknowledged again keeps that acknowledgment across restarts. It is bounded
+by the resolved-alert retention (TTL 24h by default): orphans whose resolution has already
+expired are indistinguishable from a live ack and must be un-acknowledged from the UI.
 
 **Two independent expiry mechanisms** (don't confuse them when debugging "my data vanished"):
 


### PR DESCRIPTION
## Problem

`acknowledgments.alert_key` is the alert fingerprint — an md5 of the labels alone — and the rows were only ever deleted when a user explicitly un-acknowledged. So when an acknowledged alert resolved and later fired again with identical labels, `loadAcknowledgmentsEfficiently` found the old row and flipped the new firing to acknowledged, attributed to whoever handled the *previous* incident. `getStandardAlerts()` filters acknowledged alerts out, and classic is the default display mode, so the new firing never showed up on the dashboard. It also produced an `AcknowledgedAt` predating `StartsAt`, i.e. negative MTTA / fix-time.

## Changes

- **`database/gorm_db.go`** — `CreateResolvedAlert` now runs in a transaction that creates the `resolved_alerts` row *and* deletes the live `acknowledgments` rows for that fingerprint. The snapshot already carries the history, so nothing is lost and the next firing starts clean.
- **`webui/services/alert_cache.go`** — the ack-applying loop moves into `applyAcknowledgments`, which now iterates the cache and **clears** `IsAcknowledged` / `AcknowledgedBy` / `AcknowledgedAt` / `AcknowledgeReason` for fingerprints the backend did not return, mirroring `loadCommentCountsEfficiently`. The cache converges instead of latching.
- **`database/migrate.go`** — new `cleanupResolvedAcknowledgments` custom migration deletes acknowledgments whose `alert_key` appears in `resolved_alerts`, so existing deployments don't hit the old behaviour on the first re-fire. It is bounded by the resolved-alert retention (24h default); orphans older than that are indistinguishable from a live ack and must be un-acknowledged from the UI — documented in `openwiki/backend.md`.

## Tests

- `TestAlertCache_AcknowledgmentDoesNotSurviveResolution` — full resolve → re-fire cycle at the cache level: ack applied, alert stays acknowledged across refreshes while firing, resolves, fires again with the same fingerprint, comes back **not** acknowledged with all ack fields cleared.
- `TestCreateResolvedAlertClearsAcknowledgments` — live rows dropped, snapshot preserved, other alerts' acks untouched.
- `TestCleanupResolvedAcknowledgments` — orphan deleted, acknowledgment of a still-firing alert kept.

`go build ./...`, `go vet ./internal/...` and `go test ./internal/...` pass.

Closes #101