### PR TITLE
fix(backend): enforce impersonation allowlist on gRPC RPCs

### DIFF
--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -124,8 +124,8 @@ func (s *Server) initServices() {
 	}
 
 	s.authService = services.NewAuthServiceGorm(s.db, s.oauthService)
-	s.alertService = services.NewAlertServiceGorm(s.db)
-	s.statisticsService = services.NewStatisticsServiceGorm(s.db)
+	s.alertService = services.NewAlertServiceGorm(s.db, &s.config.Admin)
+	s.statisticsService = services.NewStatisticsServiceGorm(s.db, &s.config.Admin)
 
 	// Initialize statistics worker pool
 	// 10 workers with queue size of 1000 jobs

--- a/internal/backend/services/impersonation.go
+++ b/internal/backend/services/impersonation.go
@@ -1,0 +1,26 @@
+package services
+
+import (
+	"fmt"
+	"log"
+
+	"notificator/config"
+	"notificator/internal/backend/models"
+)
+
+// resolveTargetUser returns the effective user ID for a request, enforcing the
+// backend impersonation allowlist. impersonateUserID equal to the session
+// user's own ID is always allowed. Any other value requires the session user
+// to be on adminConfig's allowlist, checked by username or email.
+func resolveTargetUser(adminConfig *config.AdminConfig, user *models.User, impersonateUserID, rpcName string) (string, error) {
+	if impersonateUserID == "" || impersonateUserID == user.ID {
+		return user.ID, nil
+	}
+
+	if adminConfig == nil || (!adminConfig.CanImpersonate(user.Username) && !adminConfig.CanImpersonate(user.Email)) {
+		log.Printf("[IMPERSONATION] denied: requester=%s (%s) target=%s rpc=%s", user.ID, user.Username, impersonateUserID, rpcName)
+		return "", fmt.Errorf("not authorized to impersonate user %s", impersonateUserID)
+	}
+
+	return impersonateUserID, nil
+}

--- a/internal/backend/services/impersonation_test.go
+++ b/internal/backend/services/impersonation_test.go
@@ -1,0 +1,178 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"gorm.io/datatypes"
+
+	"notificator/config"
+	"notificator/internal/backend/database"
+	"notificator/internal/backend/models"
+	mainmodels "notificator/internal/models"
+
+	alertpb "notificator/internal/backend/proto/alert"
+)
+
+func setupImpersonationTest(t *testing.T, allowedUsers []string) (*AlertServiceGorm, *database.GormDB, *models.User, *models.User) {
+	t.Helper()
+
+	db, err := database.NewGormDB("sqlite", config.DatabaseConfig{SQLitePath: t.TempDir() + "/test.db"})
+	if err != nil {
+		t.Fatalf("failed to create test database: %v", err)
+	}
+	if err := db.AutoMigrate(); err != nil {
+		t.Fatalf("failed to migrate test database: %v", err)
+	}
+
+	victim, err := db.CreateUser("victim", "victim@example.com", "hash")
+	if err != nil {
+		t.Fatalf("failed to create victim: %v", err)
+	}
+	requester, err := db.CreateUser("requester", "requester@example.com", "hash")
+	if err != nil {
+		t.Fatalf("failed to create requester: %v", err)
+	}
+
+	if err := db.CreateSession(victim.ID, "victim-session", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("failed to create victim session: %v", err)
+	}
+	if err := db.CreateSession(requester.ID, "requester-session", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("failed to create requester session: %v", err)
+	}
+
+	svc := NewAlertServiceGorm(db, &config.AdminConfig{ImpersonationAllowedUsers: allowedUsers})
+
+	return svc, db, victim, requester
+}
+
+func seedVictimColorPreference(t *testing.T, db *database.GormDB, victimID string) {
+	t.Helper()
+
+	err := db.SaveUserColorPreferences(victimID, []mainmodels.UserColorPreference{
+		{
+			ID:              "pref-1",
+			Color:           "red",
+			ColorType:       "custom",
+			LabelConditions: datatypes.JSON([]byte(`{}`)),
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to seed victim color preference: %v", err)
+	}
+}
+
+func TestGetUserColorPreferences_OrdinaryUserCannotImpersonate(t *testing.T) {
+	svc, db, victim, requester := setupImpersonationTest(t, nil)
+	seedVictimColorPreference(t, db, victim.ID)
+
+	resp, err := svc.GetUserColorPreferences(context.Background(), &alertpb.GetUserColorPreferencesRequest{
+		SessionId:         "requester-session",
+		ImpersonateUserId: victim.ID,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Success {
+		t.Fatalf("expected impersonation to be denied for non-admin %s", requester.Username)
+	}
+	if len(resp.Preferences) != 0 {
+		t.Fatalf("expected no preferences leaked to unauthorized requester")
+	}
+}
+
+func TestGetUserColorPreferences_AllowlistedAdminCanImpersonate(t *testing.T) {
+	svc, db, victim, _ := setupImpersonationTest(t, []string{"requester"})
+	seedVictimColorPreference(t, db, victim.ID)
+
+	resp, err := svc.GetUserColorPreferences(context.Background(), &alertpb.GetUserColorPreferencesRequest{
+		SessionId:         "requester-session",
+		ImpersonateUserId: victim.ID,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("expected allowlisted admin to impersonate successfully, got message: %s", resp.Message)
+	}
+	if len(resp.Preferences) != 1 {
+		t.Fatalf("expected 1 preference, got %d", len(resp.Preferences))
+	}
+}
+
+func TestSaveUserColorPreferences_OrdinaryUserCannotImpersonate(t *testing.T) {
+	svc, db, victim, requester := setupImpersonationTest(t, nil)
+	seedVictimColorPreference(t, db, victim.ID)
+
+	resp, err := svc.SaveUserColorPreferences(context.Background(), &alertpb.SaveUserColorPreferencesRequest{
+		SessionId:         "requester-session",
+		ImpersonateUserId: victim.ID,
+		Preferences:       nil, // empty list: would wipe the victim's preferences if honored
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Success {
+		t.Fatalf("expected impersonation to be denied for non-admin %s", requester.Username)
+	}
+
+	prefs, err := db.GetUserColorPreferences(victim.ID)
+	if err != nil {
+		t.Fatalf("failed to read back victim preferences: %v", err)
+	}
+	if len(prefs) != 1 {
+		t.Fatalf("expected victim's preference to survive denied impersonation, got %d", len(prefs))
+	}
+}
+
+func TestSaveUserColorPreferences_AllowlistedAdminCanImpersonate(t *testing.T) {
+	svc, db, victim, _ := setupImpersonationTest(t, []string{"requester"})
+	seedVictimColorPreference(t, db, victim.ID)
+
+	resp, err := svc.SaveUserColorPreferences(context.Background(), &alertpb.SaveUserColorPreferencesRequest{
+		SessionId:         "requester-session",
+		ImpersonateUserId: victim.ID,
+		Preferences:       nil,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("expected allowlisted admin to impersonate successfully, got message: %s", resp.Message)
+	}
+
+	prefs, err := db.GetUserColorPreferences(victim.ID)
+	if err != nil {
+		t.Fatalf("failed to read back victim preferences: %v", err)
+	}
+	if len(prefs) != 0 {
+		t.Fatalf("expected allowlisted admin's write to take effect, got %d preferences left", len(prefs))
+	}
+}
+
+func TestSaveUserColorPreferences_SelfImpersonationAlwaysAllowed(t *testing.T) {
+	svc, db, _, requester := setupImpersonationTest(t, nil)
+
+	resp, err := svc.SaveUserColorPreferences(context.Background(), &alertpb.SaveUserColorPreferencesRequest{
+		SessionId:         "requester-session",
+		ImpersonateUserId: requester.ID,
+		Preferences: []*alertpb.UserColorPreference{
+			{Id: "own-pref", Color: "blue", ColorType: "custom"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("expected impersonate_user_id equal to own session user to be allowed, got message: %s", resp.Message)
+	}
+
+	prefs, err := db.GetUserColorPreferences(requester.ID)
+	if err != nil {
+		t.Fatalf("failed to read back requester preferences: %v", err)
+	}
+	if len(prefs) != 1 {
+		t.Fatalf("expected 1 preference for requester, got %d", len(prefs))
+	}
+}

--- a/internal/backend/services/remove_resolved_alerts_test.go
+++ b/internal/backend/services/remove_resolved_alerts_test.go
@@ -25,7 +25,7 @@ func setupAlertServiceWithResolvedAlert(t *testing.T) (*AlertServiceGorm, *datab
 		t.Fatalf("failed to seed resolved alert: %v", err)
 	}
 
-	return NewAlertServiceGorm(db), db
+	return NewAlertServiceGorm(db, &config.AdminConfig{}), db
 }
 
 func resolvedAlertCount(t *testing.T, db *database.GormDB) int64 {

--- a/internal/backend/services/services.go
+++ b/internal/backend/services/services.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"notificator/config"
 	"notificator/internal/backend/database"
 	"notificator/internal/backend/models"
 	alertpb "notificator/internal/backend/proto/alert"
@@ -430,13 +431,15 @@ type Subscription struct {
 type AlertServiceGorm struct {
 	alertpb.UnimplementedAlertServiceServer
 	db            *database.GormDB
+	adminConfig   *config.AdminConfig
 	subscriptions map[string][]*Subscription // alertKey -> []*Subscription
 	subsMutex     sync.RWMutex
 }
 
-func NewAlertServiceGorm(db *database.GormDB) *AlertServiceGorm {
+func NewAlertServiceGorm(db *database.GormDB, adminConfig *config.AdminConfig) *AlertServiceGorm {
 	return &AlertServiceGorm{
 		db:            db,
+		adminConfig:   adminConfig,
 		subscriptions: make(map[string][]*Subscription),
 	}
 }
@@ -908,10 +911,12 @@ func (s *AlertServiceGorm) GetUserColorPreferences(ctx context.Context, req *ale
 		}, nil
 	}
 
-	// Use impersonated user ID if provided, otherwise use session user
-	targetUserID := user.ID
-	if req.ImpersonateUserId != "" {
-		targetUserID = req.ImpersonateUserId
+	targetUserID, err := resolveTargetUser(s.adminConfig, user, req.ImpersonateUserId, "GetUserColorPreferences")
+	if err != nil {
+		return &alertpb.GetUserColorPreferencesResponse{
+			Success: false,
+			Message: "Not authorized to impersonate this user",
+		}, nil
 	}
 
 	// Get user color preferences
@@ -972,10 +977,12 @@ func (s *AlertServiceGorm) SaveUserColorPreferences(ctx context.Context, req *al
 		}, nil
 	}
 
-	// Use impersonated user ID if provided, otherwise use session user
-	targetUserID := user.ID
-	if req.ImpersonateUserId != "" {
-		targetUserID = req.ImpersonateUserId
+	targetUserID, err := resolveTargetUser(s.adminConfig, user, req.ImpersonateUserId, "SaveUserColorPreferences")
+	if err != nil {
+		return &alertpb.SaveUserColorPreferencesResponse{
+			Success: false,
+			Message: "Not authorized to impersonate this user",
+		}, nil
 	}
 
 	// Convert protobuf preferences to model preferences
@@ -1047,10 +1054,12 @@ func (s *AlertServiceGorm) DeleteUserColorPreference(ctx context.Context, req *a
 		}, nil
 	}
 
-	// Use impersonated user ID if provided, otherwise use session user
-	targetUserID := user.ID
-	if req.ImpersonateUserId != "" {
-		targetUserID = req.ImpersonateUserId
+	targetUserID, err := resolveTargetUser(s.adminConfig, user, req.ImpersonateUserId, "DeleteUserColorPreference")
+	if err != nil {
+		return &alertpb.DeleteUserColorPreferenceResponse{
+			Success: false,
+			Message: "Not authorized to impersonate this user",
+		}, nil
 	}
 
 	// Delete preference
@@ -1771,10 +1780,12 @@ func (s *AlertServiceGorm) GetUserHiddenAlerts(ctx context.Context, req *alertpb
 		}, nil
 	}
 
-	// Use impersonated user ID if provided, otherwise use session user
-	targetUserID := user.ID
-	if req.ImpersonateUserId != "" {
-		targetUserID = req.ImpersonateUserId
+	targetUserID, err := resolveTargetUser(s.adminConfig, user, req.ImpersonateUserId, "GetUserHiddenAlerts")
+	if err != nil {
+		return &alertpb.GetUserHiddenAlertsResponse{
+			Success: false,
+			Message: "Not authorized to impersonate this user",
+		}, nil
 	}
 
 	// Get hidden alerts from database
@@ -1956,10 +1967,12 @@ func (s *AlertServiceGorm) GetUserHiddenRules(ctx context.Context, req *alertpb.
 		}, nil
 	}
 
-	// Use impersonated user ID if provided, otherwise use session user
-	targetUserID := user.ID
-	if req.ImpersonateUserId != "" {
-		targetUserID = req.ImpersonateUserId
+	targetUserID, err := resolveTargetUser(s.adminConfig, user, req.ImpersonateUserId, "GetUserHiddenRules")
+	if err != nil {
+		return &alertpb.GetUserHiddenRulesResponse{
+			Success: false,
+			Message: "Not authorized to impersonate this user",
+		}, nil
 	}
 
 	// Get hidden rules from database
@@ -2448,10 +2461,12 @@ func (s *AlertServiceGorm) GetFilterPresets(ctx context.Context, req *alertpb.Ge
 		}, nil
 	}
 
-	// Use impersonated user ID if provided, otherwise use session user
-	targetUserID := user.ID
-	if req.ImpersonateUserId != "" {
-		targetUserID = req.ImpersonateUserId
+	targetUserID, err := resolveTargetUser(s.adminConfig, user, req.ImpersonateUserId, "GetFilterPresets")
+	if err != nil {
+		return &alertpb.GetFilterPresetsResponse{
+			Success: false,
+			Message: "Not authorized to impersonate this user",
+		}, nil
 	}
 
 	// Get filter presets from database

--- a/internal/backend/services/statistics_grpc_service.go
+++ b/internal/backend/services/statistics_grpc_service.go
@@ -9,6 +9,7 @@ import (
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"notificator/config"
 	"notificator/internal/backend/database"
 	"notificator/internal/backend/models"
 	alertpb "notificator/internal/backend/proto/alert"
@@ -18,15 +19,17 @@ import (
 type StatisticsServiceGorm struct {
 	alertpb.UnimplementedStatisticsServiceServer
 	db             *database.GormDB
+	adminConfig    *config.AdminConfig
 	queryService   *StatisticsQueryService
 	captureService *StatisticsCaptureService
 	workerPool     *StatisticsWorkerPool
 }
 
 // NewStatisticsServiceGorm creates a new statistics gRPC service
-func NewStatisticsServiceGorm(db *database.GormDB) *StatisticsServiceGorm {
+func NewStatisticsServiceGorm(db *database.GormDB, adminConfig *config.AdminConfig) *StatisticsServiceGorm {
 	return &StatisticsServiceGorm{
 		db:             db,
+		adminConfig:    adminConfig,
 		queryService:   NewStatisticsQueryService(db),
 		captureService: NewStatisticsCaptureService(db),
 		workerPool:     nil, // Will be set later via SetWorkerPool
@@ -817,10 +820,12 @@ func (s *StatisticsServiceGorm) GetStatisticsViews(ctx context.Context, req *ale
 		}, nil
 	}
 
-	// Determine which user ID to use
-	userID := user.ID
-	if req.GetImpersonateUserId() != "" {
-		userID = req.GetImpersonateUserId()
+	userID, err := resolveTargetUser(s.adminConfig, user, req.GetImpersonateUserId(), "GetStatisticsViews")
+	if err != nil {
+		return &alertpb.GetStatisticsViewsResponse{
+			Success: false,
+			Message: "Not authorized to impersonate this user",
+		}, nil
 	}
 
 	// Get views from database
@@ -871,10 +876,12 @@ func (s *StatisticsServiceGorm) SaveStatisticsView(ctx context.Context, req *ale
 		}, nil
 	}
 
-	// Determine which user ID to use
-	userID := user.ID
-	if req.GetImpersonateUserId() != "" {
-		userID = req.GetImpersonateUserId()
+	userID, err := resolveTargetUser(s.adminConfig, user, req.GetImpersonateUserId(), "SaveStatisticsView")
+	if err != nil {
+		return &alertpb.SaveStatisticsViewResponse{
+			Success: false,
+			Message: "Not authorized to impersonate this user",
+		}, nil
 	}
 
 	// Build view data JSON
@@ -940,10 +947,12 @@ func (s *StatisticsServiceGorm) UpdateStatisticsView(ctx context.Context, req *a
 		}, nil
 	}
 
-	// Determine which user ID to use
-	userID := user.ID
-	if req.GetImpersonateUserId() != "" {
-		userID = req.GetImpersonateUserId()
+	userID, err := resolveTargetUser(s.adminConfig, user, req.GetImpersonateUserId(), "UpdateStatisticsView")
+	if err != nil {
+		return &alertpb.UpdateStatisticsViewResponse{
+			Success: false,
+			Message: "Not authorized to impersonate this user",
+		}, nil
 	}
 
 	// Get existing view
@@ -1021,10 +1030,12 @@ func (s *StatisticsServiceGorm) DeleteStatisticsView(ctx context.Context, req *a
 		}, nil
 	}
 
-	// Determine which user ID to use
-	userID := user.ID
-	if req.GetImpersonateUserId() != "" {
-		userID = req.GetImpersonateUserId()
+	userID, err := resolveTargetUser(s.adminConfig, user, req.GetImpersonateUserId(), "DeleteStatisticsView")
+	if err != nil {
+		return &alertpb.DeleteStatisticsViewResponse{
+			Success: false,
+			Message: "Not authorized to impersonate this user",
+		}, nil
 	}
 
 	// Delete from database (with ownership check)
@@ -1062,10 +1073,12 @@ func (s *StatisticsServiceGorm) SetDefaultStatisticsView(ctx context.Context, re
 		}, nil
 	}
 
-	// Determine which user ID to use
-	userID := user.ID
-	if req.GetImpersonateUserId() != "" {
-		userID = req.GetImpersonateUserId()
+	userID, err := resolveTargetUser(s.adminConfig, user, req.GetImpersonateUserId(), "SetDefaultStatisticsView")
+	if err != nil {
+		return &alertpb.SetDefaultStatisticsViewResponse{
+			Success: false,
+			Message: "Not authorized to impersonate this user",
+		}, nil
 	}
 
 	// If view_id is empty, clear the default


### PR DESCRIPTION
## Summary

- `impersonate_user_id` was honoured by eleven gRPC RPCs across `AlertServiceGorm` and `StatisticsServiceGorm` with no authorization check — only the WebUI gated impersonation via `canImpersonate`. Any session that could reach the gRPC port (exposed via `docker-compose.yml` and the Kubernetes `backend-service`) could read or overwrite another user's color preferences, hidden alerts/rules, filter presets and statistics views.
- `SaveUserColorPreferences` was the worst case: it unscoped-deletes all of the target user's color preferences before recreating them, so a single call with an empty preference list permanently wiped a victim's configuration.
- Added `resolveTargetUser()` (`internal/backend/services/impersonation.go`), a single helper used at all eleven call sites that resolves the effective user ID: self-impersonation (`impersonate_user_id == session user`) always succeeds, anything else requires the requester to be on the backend's admin allowlist (`config.AdminConfig`, the same config the WebUI already uses), and denied attempts are logged with requester, target and RPC name.
- Threaded `*config.AdminConfig` into `NewAlertServiceGorm` / `NewStatisticsServiceGorm` and wired it from `internal/backend/server.go` (`&s.config.Admin`).

## Test plan

- New tests in `internal/backend/services/impersonation_test.go` cover both directions for a read RPC (`GetUserColorPreferences`) and the destructive write RPC (`SaveUserColorPreferences`): ordinary user denied (target data unchanged), allowlisted admin succeeds, and self-impersonation still works.
- `go build ./...`
- `go vet ./...`
- `go test ./...` (116 passed)

Closes #103

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>