### PR TITLE
docs(wiki): sync with recent changes

### DIFF
--- a/openwiki/.last-update.json
+++ b/openwiki/.last-update.json
@@ -1,6 +1,6 @@
 {
-  "updatedAt": "2026-07-07T10:09:14.000Z",
+  "updatedAt": "2026-07-26T05:34:04.000Z",
   "command": "update",
-  "gitHead": "ba5a4442821985280cb4f5234e6f027348332947",
-  "model": "claude-opus-4-8"
+  "gitHead": "d6ce9d5fdcf45e4ac5d830f28f3bbbfeb001dbcc",
+  "model": "claude-sonnet-5"
 }

--- a/openwiki/backend.md
+++ b/openwiki/backend.md
@@ -33,9 +33,17 @@ The entire auth model is: **every RPC takes a `session_id` string and calls
 - `Login` creates a bcrypt-checked `User` session with a random hex `session_id`, 7-day expiry
   (`internal/backend/services/services.go`). `User` supports both local password and OAuth
   identity (`OAuthProvider`/`OAuthID`, `internal/backend/models/models.go`).
-- **No enforced RBAC.** `models/oauth_models.go` defines `UserRole` and OAuth group-sync
-  machinery, but nothing gates an RPC by role. `GetConnectedUsers` is commented "admin only"
-  yet only checks that *some* valid session exists. Do not trust "admin only" comments.
+- **No enforced RBAC**, with one exception: impersonation. `models/oauth_models.go` defines
+  `UserRole` and OAuth group-sync machinery, but nothing gates an RPC by role, and
+  `GetConnectedUsers` is commented "admin only" yet only checks that *some* valid session
+  exists — do not trust "admin only" comments elsewhere. Impersonation itself **is** enforced:
+  every `AlertServiceGorm` / `StatisticsServiceGorm` RPC that accepts `impersonate_user_id`
+  resolves the effective user through `resolveTargetUser()`
+  (`services/impersonation.go`), which rejects the request unless the caller is on
+  `config.AdminConfig`'s allowlist (checked by username or email) and logs denied attempts.
+  Before this, only the WebUI's `canImpersonate` gated it — a direct gRPC call could read or
+  overwrite any other user's color preferences, hidden alerts/rules, filter presets, and
+  statistics views.
 
 ## Database
 

--- a/openwiki/dashboard.md
+++ b/openwiki/dashboard.md
@@ -147,12 +147,11 @@ connected, its comments and acknowledgments.
 Tabs: **Overview**, **Details** (fingerprint, generator URL), **Labels** / **Annotations**
 (copy-to-clipboard), **Acknowledgments**, **Comments** (add/delete; system comments show a badge),
 **History** (lazy `GET /alert/:fp/history` → up to 50 fire/resolve/ack occurrences with MTTR/MTTA),
-and **Sentry** (only if the alert carries a `sentry` annotation/label; lazy-loaded). Header offers
-Silence/Unsilence, configurable per-user **annotation buttons**, Ack/Unack, "Source"
-(`generatorURL`), and "Copy as Issue" (builds a Markdown issue and copies it).
-
-> ⚠️ The modal's `Silences` field is **always empty** (`dashboard_handlers.go:1289`, not
-> implemented) — only `status.silencedBy` IDs are available.
+**Silences** (matchers, creator, comment, end time — resolved from the alert's own Alertmanager;
+see [domain](domain.md#silences)), and **Sentry** (only if the alert carries a `sentry`
+annotation/label; lazy-loaded). Header offers Silence/Unsilence, configurable per-user
+**annotation buttons**, Ack/Unack, "Source" (`generatorURL`), and "Copy as Issue" (builds a
+Markdown issue and copies it).
 
 ## Filter presets, resolved view, colors
 

--- a/openwiki/domain.md
+++ b/openwiki/domain.md
@@ -34,6 +34,27 @@ labels, the same logical alert has the same fingerprint across different Alertma
 **inhibited** when another alert suppresses it (`InhibitedBy`). **Resolved** means it stopped
 firing — at which point the WebUI archives it (see resolved alerts below).
 
+## Silences {#silences}
+
+A silence is created **per Alertmanager**, not centrally: one logical silence the user creates
+becomes N independent copies, one per configured source, each with its own ID and lifecycle. The
+`/silences` page (`internal/webui/handlers/silence_handlers.go`,
+`MultiClient.FetchAllSilencesDetailed`) is the read/audit surface over all of them — source +
+state + free-text filters, soonest-expiry sort, an expiring-soon badge, and a **matched-alert
+count** per silence (computed against the in-memory alert cache, same-source only, so it costs no
+extra Alertmanager traffic). Zero-match active silences surface as a cleanup worklist.
+
+**Extend** re-POSTs the silence with the same ID and a later `EndsAt` — Alertmanager upserts on
+ID, but if the silence lapsed first, Alertmanager mints a *new* ID instead of extending; the
+handler detects this (compares the returned ID) and answers `409` rather than silently returning
+the stale, pre-extend payload. **Expire** deletes the silence from its source only. Unknown
+sources and stale/unknown silence IDs map to `4xx` (`ErrSilenceNotFound` → `404`), not `502` —
+the fetch-per-source pattern mirrors `FetchAllAlertsDetailed` (see [webui](webui.md#alert-cache)):
+one unreachable Alertmanager degrades that source rather than blanking the page.
+
+> `SilenceMatcher.IsEqual` defaults to `true` on unmarshal — Alertmanager before 0.22 omits the
+> field, and decoding it as Go's zero value (`false`) silently negates every matcher.
+
 ## Filtering
 
 `internal/filters/filter.go` — `AlertFilter{SearchText, Severity, Status, Team}` with
@@ -63,7 +84,8 @@ These live in the backend DB and are edited over gRPC (`proto/alert.proto`, `Ale
   toggles and dashboard column layout.
 
 All of these accept an optional `impersonate_user_id` so an admin can manage another user's data
-(see [webui](webui.md#auth)).
+(see [webui](webui.md#auth)). The backend enforces this itself via `resolveTargetUser`
+(see [backend](backend.md#auth)) — it is not just a WebUI-side check.
 
 ## Statistics & on-call analytics {#statistics}
 

--- a/openwiki/webui.md
+++ b/openwiki/webui.md
@@ -82,9 +82,11 @@ This is separate from the backend's gRPC collaboration stream — see
   Day.js from CDN; contains inline dark-mode, impersonation-banner, and connected-users JS.
 - `pages/` — `NewDashboard` (the **live operational dashboard**, `/dashboard` — deep-dived in
   [dashboard](dashboard.md)), `StatisticsDashboard` (the **historical analytics dashboard**,
-  `/statistics` — deep-dived in [statistics](statistics.md)), `Login`, `Register`, `Profile`,
-  `OAuthCallback`, `Index`, `Playground` (dev/demo landing when `WebUI.Playground` is on).
-  Browser/sound alerts are covered in [notifications](notifications.md).
+  `/statistics` — deep-dived in [statistics](statistics.md)), the **silence inventory**
+  (`/silences` — read/extend/expire across all Alertmanagers, see
+  [domain](domain.md#silences)), `Login`, `Register`, `Profile`, `OAuthCallback`, `Index`,
+  `Playground` (dev/demo landing when `WebUI.Playground` is on). Browser/sound alerts are
+  covered in [notifications](notifications.md).
 - `components/` — tables, modals, filter/group views, timezone selector, page navigator, etc.
 - `scripts/` — **`.templ` files whose entire body is a `<script>` of hand-written Alpine.js**
   (e.g. `dashboard_core.templ` defines `function newDashboard(){…}`). Included into pages via


### PR DESCRIPTION
Automated openwiki refresh covering:
feat(silences): add silence inventory page with extend and expire actions
fix(silences): map client errors to 4xx and detect lapsed extends by ID
feat(devtools): show human-gate queue in the factory TUI
fix(devtools): key the human-gate tray on ready-to-merge
fix(alertmanager): bound the health probe drain and make the fan-out tests assert behaviour
feat(devtools): factory TUI alarm panel — failed units and stalled loops
fix(devtools): keep factory TUI stall clocks across transient looper failures
fix(devtools): gate factory TUI stall pruning on `looper ps` parse success
fix(devtools): ignore queue time, alarm on dead looper, cap the alarm panel
fix(devtools): guard looper schema drift, type the alarm tail, label signals
fix(devtools): dedupe factory TUI helpers colliding after the rebase
fix(devtools): surface manual_intervention and core-dump signals
fix(devtools): pin the systemd property contract, guard the stall knob
fix(devtools): pin the alarm row cap, pluralise restarts in French
fix(devtools): lead the stall row with its clock, drop the empty exit status
fix(webui): drop failed and invalidated hidden-alert fetches from the TTL cache
fix(webui): keep hidden-alert cache consistent for clear-all and impersonation
fix(webui): clear the hidden-alert entry when a mutation lands mid-fetch
fix(devtools): debounce the looper:down klaxon, alarm on manual_intervention
fix(webui): harden the resolved-alerts count against stale and bogus values
fix(webui): keep the resolved list alive when only the count query fails
fix(webui): sync the alert modal with browser Back/Forward
fix(webui): stop chained opens and failed loads from driving history
feat(devtools): factory TUI dynamic desks — one desk per concurrent loop (#81)
fix(webui): surface Sentry test and settings-save outcomes in the modal (#99)
feat(factory-tui): live agent-to-agent threads via events.jsonl (#107)
fix(backend): enforce impersonation allowlist on gRPC RPCs (#108)

<!-- doc-agent -->