### PR TITLE
fix(backend): require a real NOTIFICATOR_ENCRYPTION_KEY for Sentry token encryption

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,7 @@
 # Session secret for cookie encryption (REQUIRED for session persistence across restarts)
 # Generate with: openssl rand -hex 32
 NOTIFICATOR_SESSION_SECRET=your-64-character-hex-secret-here
+
+# Encryption key for Sentry personal tokens at rest (REQUIRED - backend refuses to start without it)
+# Generate with: openssl rand -hex 32
+NOTIFICATOR_ENCRYPTION_KEY=your-64-character-hex-secret-here

--- a/ENVIRONMENT_VARIABLES.md
+++ b/ENVIRONMENT_VARIABLES.md
@@ -45,6 +45,14 @@ The following standard database environment variables are also supported:
 - `DB_SSL_MODE` / `DATABASE_SSL_MODE` - SSL mode
 - `DB_PATH` / `DATABASE_PATH` - SQLite file path
 
+## Security Configuration
+
+- `NOTIFICATOR_ENCRYPTION_KEY` - **Required.** AES-256 key encrypting Sentry personal tokens at
+  rest, as 64 lowercase hex characters (32 bytes). The backend logs an error and exits non-zero at
+  startup if this is unset or invalid. Generate with: `openssl rand -hex 32`.
+  Rotating this key makes previously stored Sentry personal tokens unrecoverable; affected users
+  must re-enter their token via the Sentry settings modal.
+
 ## WebUI Configuration
 
 - `NOTIFICATOR_WEBUI_LISTEN` - WebUI server listen address (default: ":8081")

--- a/charts/notificator-app/values.yaml
+++ b/charts/notificator-app/values.yaml
@@ -55,7 +55,11 @@ backend:
     # NOTIFICATOR_BACKEND_ENABLED: "true"
     # NOTIFICATOR_BACKEND_GRPC_LISTEN: ":50051"
     # NOTIFICATOR_BACKEND_HTTP_LISTEN: ":8080"
-    
+
+    # Encryption key for Sentry personal tokens at rest (REQUIRED - backend refuses to start
+    # without it). 64 lowercase hex characters, generate with: openssl rand -hex 32
+    # NOTIFICATOR_ENCRYPTION_KEY: "your-64-character-hex-secret-here"
+
     # Database configuration - PostgreSQL URL (recommended)
     # POSTGRES_URL: "postgres://user:password@host:5432/database?sslmode=require"
     

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,9 @@ services:
       - NOTIFICATOR_SENTRY_BASE_URL=https://sentry.example.com
       - NOTIFICATOR_SENTRY_GLOBAL_TOKEN=""
 
+      # Encryption key for Sentry personal tokens at rest (REQUIRED, generate with: openssl rand -hex 32)
+      - NOTIFICATOR_ENCRYPTION_KEY=${NOTIFICATOR_ENCRYPTION_KEY}
+
       # Logging
       - NOTIFICATOR_LOG_LEVEL=info
     depends_on:

--- a/internal/backend/database/sentry_db.go
+++ b/internal/backend/database/sentry_db.go
@@ -5,6 +5,7 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -12,22 +13,38 @@ import (
 	"notificator/internal/backend/models"
 )
 
-// Encryption key for tokens - should be from environment variable
+// EncryptionKeyEnvVar is the environment variable holding the AES-256 key
+// used to encrypt Sentry personal tokens at rest.
+const EncryptionKeyEnvVar = "NOTIFICATOR_ENCRYPTION_KEY"
+
+// ValidateEncryptionKey checks that NOTIFICATOR_ENCRYPTION_KEY is set to 64
+// lowercase hex characters (32 raw bytes), returning an error naming the
+// variable and the generation command otherwise.
+func ValidateEncryptionKey() error {
+	_, err := encryptionKeyFromEnv()
+	return err
+}
+
+func encryptionKeyFromEnv() ([]byte, error) {
+	key := os.Getenv(EncryptionKeyEnvVar)
+	if len(key) != 64 {
+		return nil, fmt.Errorf("%s must be set to 64 lowercase hex characters (32 bytes); generate one with `openssl rand -hex 32`", EncryptionKeyEnvVar)
+	}
+	keyBytes, err := hex.DecodeString(key)
+	if err != nil {
+		return nil, fmt.Errorf("%s must be 64 lowercase hex characters (32 bytes); generate one with `openssl rand -hex 32`", EncryptionKeyEnvVar)
+	}
+	return keyBytes, nil
+}
+
 func getEncryptionKey() []byte {
-	key := os.Getenv("NOTIFICATOR_ENCRYPTION_KEY")
-	if key == "" {
-		// Generate a default key for development - DO NOT USE IN PRODUCTION
-		key = "dev-encryption-key-32-bytes-long"
+	key, err := encryptionKeyFromEnv()
+	if err != nil {
+		// ValidateEncryptionKey is called at startup, so this can only be
+		// reached if the environment changed after the process started.
+		panic(err)
 	}
-	// Ensure key is 32 bytes for AES-256
-	keyBytes := []byte(key)
-	if len(keyBytes) < 32 {
-		// Pad with zeros
-		padded := make([]byte, 32)
-		copy(padded, keyBytes)
-		return padded
-	}
-	return keyBytes[:32]
+	return key
 }
 
 // Encrypt encrypts plaintext using AES

--- a/internal/backend/database/sentry_db_test.go
+++ b/internal/backend/database/sentry_db_test.go
@@ -1,0 +1,48 @@
+package database
+
+import "testing"
+
+func TestValidateEncryptionKey(t *testing.T) {
+	cases := map[string]struct {
+		key     string
+		wantErr bool
+	}{
+		"unset":        {"", true},
+		"too short":    {"secret", true},
+		"63 hex chars": {"e4b6836c113e437c8353013501173098d2f496cd9d70afa96896057d495d88c", true},
+		"64 hex chars": {"e4b6836c113e437c8353013501173098d2f496cd9d70afa96896057d495d88cd", false},
+		"65 hex chars": {"e4b6836c113e437c8353013501173098d2f496cd9d70afa96896057d495d88cd0", true},
+		"64 non-hex":   {"zzb6836c113e437c8353013501173098d2f496cd9d70afa96896057d495d88cd", true},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(EncryptionKeyEnvVar, tc.key)
+			err := ValidateEncryptionKey()
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error for key %q, got nil", tc.key)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error for key %q, got %v", tc.key, err)
+			}
+		})
+	}
+}
+
+func TestEncryptDecryptRoundTrip(t *testing.T) {
+	t.Setenv(EncryptionKeyEnvVar, "e4b6836c113e437c8353013501173098d2f496cd9d70afa96896057d495d88cd")
+
+	const token = "sentry-personal-token-abc123"
+	ciphertext, err := encrypt(token)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	plaintext, err := decrypt(ciphertext)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if plaintext != token {
+		t.Fatalf("expected %q, got %q", token, plaintext)
+	}
+}

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -46,6 +46,10 @@ func NewServer(cfg *config.Config, dbType string) *Server {
 }
 
 func (s *Server) Start() error {
+	if err := database.ValidateEncryptionKey(); err != nil {
+		return fmt.Errorf("invalid encryption key configuration: %w", err)
+	}
+
 	if err := s.initDatabase(); err != nil {
 		return fmt.Errorf("failed to initialize database: %w", err)
 	}

--- a/openwiki/backend.md
+++ b/openwiki/backend.md
@@ -111,5 +111,6 @@ only** (no cross-replica fan-out). See [architecture](architecture.md#real-time)
   is inline in `AlertServiceGorm`.
 - **Silent job drops:** statistics worker pool drops events when full, with no alerting.
 - **Single-replica constraint:** in-memory subscriptions break under horizontal scaling.
-- **Encryption key fallback:** Sentry token storage falls back to a hardcoded dev key if
-  `NOTIFICATOR_ENCRYPTION_KEY` is unset — see [configuration](configuration.md#sentry).
+- **Encryption key is mandatory:** the backend refuses to start (non-zero exit before the gRPC
+  server accepts connections) unless `NOTIFICATOR_ENCRYPTION_KEY` is set to a valid 64-hex key —
+  see [configuration](configuration.md#sentry).

--- a/openwiki/configuration.md
+++ b/openwiki/configuration.md
@@ -76,10 +76,12 @@ tokens are stored **AES-256-GCM encrypted** (`internal/backend/database/sentry_d
 time the WebUI resolves the user's own token → the admin `GlobalToken` fallback → none, and
 enriches alerts from Sentry issue URLs found in annotations/labels.
 
-> ⚠️ **Security gotcha:** the encryption key comes from `NOTIFICATOR_ENCRYPTION_KEY`, but falls
-> back to a **hardcoded dev key** if unset — and this var is **not** documented in
-> `ENVIRONMENT_VARIABLES.md` or `.env.example`. Set it in any real deployment that stores Sentry
-> tokens, or those tokens are encrypted with a publicly-known key.
+> **`NOTIFICATOR_ENCRYPTION_KEY` is mandatory.** It must be 64 lowercase hex characters (32 bytes,
+> generate with `openssl rand -hex 32`); the backend logs an error and exits non-zero at startup
+> if it is unset or invalid, whether or not Sentry is enabled — there is no built-in fallback key.
+> Rotating the key (or setting it for the first time on a deployment that ran without one) makes
+> previously stored Sentry personal tokens unrecoverable; affected users must re-enter their token
+> via the Sentry settings modal. Documented in `ENVIRONMENT_VARIABLES.md` and `.env.example`.
 
 ## Session secret
 


### PR DESCRIPTION
## Summary
- Sentry personal access tokens were "encrypted" with a key hardcoded in this repo (`dev-encryption-key-32-bytes-long`) whenever `NOTIFICATOR_ENCRYPTION_KEY` was unset, and any shorter configured key was silently zero-padded to 32 bytes — both cases were invisible on every deployment surface (no `.env.example`/`docker-compose.yml`/Helm entry, no startup warning).
- `internal/backend/database/sentry_db.go`: replaced `getEncryptionKey`'s silent fallback/padding with strict validation — the key must be 64 lowercase hex characters (32 raw bytes), matching the format already used for `NOTIFICATOR_SESSION_SECRET`. Added `ValidateEncryptionKey()` for startup use.
- `internal/backend/server.go`: `Start()` now calls `database.ValidateEncryptionKey()` first and returns an error (which `cmd/backend.go` turns into `log.Fatalf`, i.e. non-zero exit) before initializing the database or starting the gRPC server — unconditionally, since Sentry RPCs are always registered.
- Documented `NOTIFICATOR_ENCRYPTION_KEY` (with the `openssl rand -hex 32` generation command) in `.env.example`, `ENVIRONMENT_VARIABLES.md`, `docker-compose.yml`, and the backend `env` block of `charts/notificator-app/values.yaml`.
- Corrected `openwiki/configuration.md` and `openwiki/backend.md`, which previously documented the fallback as expected behavior — they now state the key is mandatory and that rotating/first-setting it makes previously stored tokens unrecoverable.

## Breaking change
Every existing deployment must set `NOTIFICATOR_ENCRYPTION_KEY` before the next rollout — the backend now refuses to start without it, even for deployments that don't use Sentry. Sentry personal tokens stored under the old hardcoded or zero-padded key are unrecoverable and must be re-entered via the Sentry settings modal (decrypt failures already surfaced as an error from `GetUserSentryConfig`, so this is a read-time error, not corruption).

Closes #63

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/backend/...`
- [x] `go test ./internal/backend/...` (25 passed, incl. new `sentry_db_test.go` covering unset/short/63-hex/64-hex/65-hex/non-hex keys and an encrypt/decrypt round trip)
- [x] `rg 'dev-encryption-key'` and `rg 'Pad with zeros' internal/backend/` both return nothing

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>