### PR TITLE
fix(backend): restrict RemoveAllResolvedAlerts to admins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,7 @@ NOTIFICATOR_SESSION_SECRET=your-64-character-hex-secret-here
 # Encryption key for Sentry personal tokens at rest (REQUIRED - backend refuses to start without it)
 # Generate with: openssl rand -hex 32
 NOTIFICATOR_ENCRYPTION_KEY=your-64-character-hex-secret-here
+
+# Comma-separated usernames/emails allowed to perform team-wide destructive maintenance
+# actions (e.g. deleting all resolved alerts). Empty by default (no one is admin).
+NOTIFICATOR_ADMIN_USERS=

--- a/ENVIRONMENT_VARIABLES.md
+++ b/ENVIRONMENT_VARIABLES.md
@@ -53,6 +53,16 @@ The following standard database environment variables are also supported:
   Rotating this key makes previously stored Sentry personal tokens unrecoverable; affected users
   must re-enter their token via the Sentry settings modal.
 
+## Admin Configuration
+
+- `NOTIFICATOR_ADMIN_USERS` - Comma-separated usernames/emails allowed to perform team-wide
+  destructive maintenance actions (e.g. `RemoveAllResolvedAlerts`). Empty by default, meaning
+  no one can perform these actions until explicitly configured. Distinct from
+  `NOTIFICATOR_ADMIN_IMPERSONATION_ALLOWED_USERS`, which only grants the ability to act as
+  another user and does not imply admin rights.
+- `NOTIFICATOR_ADMIN_IMPERSONATION_ALLOWED_USERS` - Comma-separated usernames/emails allowed to
+  impersonate other users via `impersonate_user_id` on gRPC RPCs.
+
 ## WebUI Configuration
 
 - `NOTIFICATOR_WEBUI_LISTEN` - WebUI server listen address (default: ":8081")

--- a/charts/notificator-app/values.yaml
+++ b/charts/notificator-app/values.yaml
@@ -60,6 +60,10 @@ backend:
     # without it). 64 lowercase hex characters, generate with: openssl rand -hex 32
     # NOTIFICATOR_ENCRYPTION_KEY: "your-64-character-hex-secret-here"
 
+    # Comma-separated usernames/emails allowed to perform team-wide destructive maintenance
+    # actions (e.g. deleting all resolved alerts). Empty by default (no one is admin).
+    # NOTIFICATOR_ADMIN_USERS: "alice,bob@example.com"
+
     # Database configuration - PostgreSQL URL (recommended)
     # POSTGRES_URL: "postgres://user:password@host:5432/database?sslmode=require"
     

--- a/config/config.go
+++ b/config/config.go
@@ -29,12 +29,26 @@ type Config struct {
 
 type AdminConfig struct {
 	ImpersonationAllowedUsers []string `json:"impersonation_allowed_users"`
+	Users                     []string `json:"users"`
 }
 
 // CanImpersonate checks if a user (by username or email) is allowed to impersonate others
 func (a *AdminConfig) CanImpersonate(usernameOrEmail string) bool {
 	for _, allowed := range a.ImpersonationAllowedUsers {
 		if strings.EqualFold(allowed, usernameOrEmail) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsAdmin checks if a user (by username or email) holds admin rights.
+// This is a distinct capability from impersonation: the impersonation
+// allowlist grants "act as another user", not team-wide destructive
+// maintenance actions.
+func (a *AdminConfig) IsAdmin(usernameOrEmail string) bool {
+	for _, admin := range a.Users {
+		if strings.EqualFold(admin, usernameOrEmail) {
 			return true
 		}
 	}
@@ -335,6 +349,19 @@ func LoadConfigWithViper() (*Config, error) {
 		cfg.Admin.ImpersonationAllowedUsers = cleanUsers
 	}
 
+	// Load Admin users allowed to perform team-wide destructive maintenance
+	// actions (e.g. RemoveAllResolvedAlerts) from environment variable (comma-separated)
+	if adminUsersEnv := os.Getenv("NOTIFICATOR_ADMIN_USERS"); adminUsersEnv != "" {
+		users := strings.Split(adminUsersEnv, ",")
+		var cleanUsers []string
+		for _, u := range users {
+			if trimmed := strings.TrimSpace(u); trimmed != "" {
+				cleanUsers = append(cleanUsers, trimmed)
+			}
+		}
+		cfg.Admin.Users = cleanUsers
+	}
+
 	// Load Sentry configuration if enabled
 	if viper.GetBool("sentry.enabled") {
 		cfg.Sentry = &SentryConfig{
@@ -562,9 +589,11 @@ func setViperDefaults(cfg *Config) {
 
 	// Admin defaults
 	viper.SetDefault("admin.impersonation_allowed_users", []string{})
+	viper.SetDefault("admin.users", []string{})
 
 	// Admin environment variable bindings
 	viper.BindEnv("admin.impersonation_allowed_users", "NOTIFICATOR_ADMIN_IMPERSONATION_ALLOWED_USERS")
+	viper.BindEnv("admin.users", "NOTIFICATOR_ADMIN_USERS")
 
 	// Alertmanager defaults - DISABLED to allow JSON config to work properly
 	// The alertmanager configuration should come from the config file, not defaults

--- a/internal/backend/services/remove_resolved_alerts_test.go
+++ b/internal/backend/services/remove_resolved_alerts_test.go
@@ -10,7 +10,7 @@ import (
 	alertpb "notificator/internal/backend/proto/alert"
 )
 
-func setupAlertServiceWithResolvedAlert(t *testing.T) (*AlertServiceGorm, *database.GormDB) {
+func setupAlertServiceWithResolvedAlert(t *testing.T, adminUsers ...string) (*AlertServiceGorm, *database.GormDB) {
 	t.Helper()
 
 	db, err := database.NewGormDB("sqlite", config.DatabaseConfig{SQLitePath: t.TempDir() + "/test.db"})
@@ -25,7 +25,7 @@ func setupAlertServiceWithResolvedAlert(t *testing.T) (*AlertServiceGorm, *datab
 		t.Fatalf("failed to seed resolved alert: %v", err)
 	}
 
-	return NewAlertServiceGorm(db, &config.AdminConfig{}), db
+	return NewAlertServiceGorm(db, &config.AdminConfig{Users: adminUsers}), db
 }
 
 func resolvedAlertCount(t *testing.T, db *database.GormDB) int64 {
@@ -67,8 +67,34 @@ func TestRemoveAllResolvedAlerts_RejectsInvalidSession(t *testing.T) {
 	}
 }
 
-func TestRemoveAllResolvedAlerts_ValidSessionDeletes(t *testing.T) {
+func TestRemoveAllResolvedAlerts_RejectsNonAdmin(t *testing.T) {
 	svc, db := setupAlertServiceWithResolvedAlert(t)
+
+	user, err := db.CreateUser("tester", "tester@example.com", "hash")
+	if err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+	if err := db.CreateSession(user.ID, "session-1", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("failed to create session: %v", err)
+	}
+
+	resp, err := svc.RemoveAllResolvedAlerts(context.Background(), &alertpb.RemoveAllResolvedAlertsRequest{SessionId: "session-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Success {
+		t.Error("expected Success=false for non-admin session")
+	}
+	if resp.Message != "Admin rights required" {
+		t.Errorf("expected admin-required message, got: %s", resp.Message)
+	}
+	if count := resolvedAlertCount(t, db); count != 1 {
+		t.Errorf("expected resolved alerts untouched, got count %d", count)
+	}
+}
+
+func TestRemoveAllResolvedAlerts_ValidAdminSessionDeletes(t *testing.T) {
+	svc, db := setupAlertServiceWithResolvedAlert(t, "tester")
 
 	user, err := db.CreateUser("tester", "tester@example.com", "hash")
 	if err != nil {

--- a/internal/backend/services/services.go
+++ b/internal/backend/services/services.go
@@ -1225,6 +1225,14 @@ func (s *AlertServiceGorm) RemoveAllResolvedAlerts(ctx context.Context, req *ale
 		}, nil
 	}
 
+	if s.adminConfig == nil || (!s.adminConfig.IsAdmin(user.Username) && !s.adminConfig.IsAdmin(user.Email)) {
+		log.Printf("RemoveAllResolvedAlerts: denied, requester=%s (%s) is not an admin", user.ID, user.Username)
+		return &alertpb.RemoveAllResolvedAlertsResponse{
+			Success: false,
+			Message: "Admin rights required",
+		}, nil
+	}
+
 	log.Printf("RemoveAllResolvedAlerts: User %s (ID: %s) requested removal of all resolved alerts", user.Username, user.ID)
 
 	removedCount, err := s.db.RemoveAllResolvedAlerts()


### PR DESCRIPTION
## Summary

- `RemoveAllResolvedAlerts` previously only checked for a valid session (the #65 fix), so any authenticated user could hard-delete every resolved alert for the whole team — wiping audit trail/MTTR data irreversibly.
- After the session check succeeds, the RPC now requires the caller to be on a new admin allowlist and returns `Success:false, Message:"Admin rights required"` otherwise; the deletion path and existing session-error behavior are unchanged.

## Admin mechanism decision

Added a dedicated `config.AdminConfig.Users` list with an `IsAdmin(usernameOrEmail)` helper, fed by a new `NOTIFICATOR_ADMIN_USERS` env var — kept separate from `ImpersonationAllowedUsers`/`CanImpersonate` (`NOTIFICATOR_ADMIN_IMPERSONATION_ALLOWED_USERS`), per the issue's guidance not to silently overload the impersonation capability for a different authorization decision. No DB schema change; `AlertServiceGorm` already carried `*config.AdminConfig`, so this only extends that struct and its RPC-side check.

## Changes

- `config/config.go`: `AdminConfig.Users` field + `IsAdmin()`, env loading/viper binding for `NOTIFICATOR_ADMIN_USERS`.
- `internal/backend/services/services.go`: admin gate in `RemoveAllResolvedAlerts` after `GetUserBySession`.
- `internal/backend/services/remove_resolved_alerts_test.go`: updated existing valid-session test to seed an admin user; added `TestRemoveAllResolvedAlerts_RejectsNonAdmin` and renamed the success test to `TestRemoveAllResolvedAlerts_ValidAdminSessionDeletes`.
- `.env.example`, `ENVIRONMENT_VARIABLES.md`, `charts/notificator-app/values.yaml`: documented `NOTIFICATOR_ADMIN_USERS`.

The webui's own gate on this action (`canImpersonate`) is unchanged — per the issue, it's UX only; the backend RPC is the actual trust boundary, and it already surfaces the "Admin rights required" message back through the existing error-forwarding path.

Closes #68

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (125 passed, 27 packages)
- [x] New tests cover: non-admin valid session denied (no deletion), admin valid session succeeds and deletes, missing/invalid session behavior from #65 preserved

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>