### PR TITLE
docs(wiki): sync with recent changes

### DIFF
--- a/openwiki/.last-update.json
+++ b/openwiki/.last-update.json
@@ -1,6 +1,6 @@
 {
-  "updatedAt": "2026-07-07T10:09:14.000Z",
+  "updatedAt": "2026-07-27T05:32:37.000Z",
   "command": "update",
-  "gitHead": "ba5a4442821985280cb4f5234e6f027348332947",
-  "model": "claude-opus-4-8"
+  "gitHead": "7535af3a6491053216864e226841787166ceee43",
+  "model": "claude-sonnet-5"
 }

--- a/openwiki/backend.md
+++ b/openwiki/backend.md
@@ -33,9 +33,15 @@ The entire auth model is: **every RPC takes a `session_id` string and calls
 - `Login` creates a bcrypt-checked `User` session with a random hex `session_id`, 7-day expiry
   (`internal/backend/services/services.go`). `User` supports both local password and OAuth
   identity (`OAuthProvider`/`OAuthID`, `internal/backend/models/models.go`).
-- **No enforced RBAC.** `models/oauth_models.go` defines `UserRole` and OAuth group-sync
-  machinery, but nothing gates an RPC by role. `GetConnectedUsers` is commented "admin only"
-  yet only checks that *some* valid session exists. Do not trust "admin only" comments.
+- **No enforced RBAC**, with one exception. `models/oauth_models.go` defines `UserRole` and OAuth
+  group-sync machinery, but nothing gates an RPC by role. `GetConnectedUsers` is commented "admin
+  only" yet only checks that *some* valid session exists. Do not trust "admin only" comments. The
+  one real gate is `AdminConfig.IsAdmin` (`config/config.go`) — a `NOTIFICATOR_ADMIN_USERS`
+  username/email allowlist, unrelated to `UserRole` — which `RemoveAllResolvedAlerts` checks before
+  deleting all resolved alerts; empty by default, so no one can call it until configured. Distinct
+  from the impersonation allowlist (`NOTIFICATOR_ADMIN_IMPERSONATION_ALLOWED_USERS`, see
+  [architecture](architecture.md#real-time)), which grants acting as another user, not admin
+  rights.
 
 ## Database
 
@@ -121,7 +127,9 @@ only** (no cross-replica fan-out). See [architecture](architecture.md#real-time)
 ## Gotchas {#gotchas}
 
 - **No auth interceptor** — forgetting the per-RPC `session_id` check = an unauthenticated RPC.
-- **"Admin only" is not enforced** anywhere despite the `UserRole`/group infra existing.
+- **"Admin only" is not enforced by `UserRole`** despite the group infra existing — the one
+  exception is `RemoveAllResolvedAlerts`, gated by the separate `NOTIFICATOR_ADMIN_USERS`
+  allowlist (see [auth](#auth)).
 - **Dead code:** `services/comment_service.go` and `services/acknowledgment_service.go` define
   `CommentService`/`AcknowledgmentService` whose constructors are never called — the real logic
   is inline in `AlertServiceGorm`.

--- a/openwiki/dashboard.md
+++ b/openwiki/dashboard.md
@@ -65,6 +65,12 @@ path (genuine Alertmanager resolves) it evicts removed fingerprints from the not
 so re-fires re-notify; the poll path does not, because its `removedAlerts` conflate resolve with
 filter-out. See [notifications](notifications.md#what-triggers-a-notification).
 
+> `applyIncrementalUpdate`'s handling of `update.updatedAlerts` mirrors the display-mode filters
+> (`getStandardAlerts`/`getAcknowledgedAlerts`): an update to an alert already in the visible list
+> is dropped from view if it no longer matches (e.g. newly acknowledged, in classic mode), and an
+> update to an alert **not yet in the list** is added if it now matches (e.g. newly acknowledged,
+> in acknowledge mode) — instead of being silently ignored.
+
 > ⚠️ **SSE broadcasts unfiltered, colorless data to every subscriber.** The server does no
 > per-user filtering on the SSE path (unlike the polling path). Therefore the client re-applies
 > filters itself via **`alertMatchesFilters()`** (`dashboard_data.templ:421`) — a full JS
@@ -117,7 +123,10 @@ preset. Server validates configs (unique id/order, width bounds, allowed formatt
 ## Alert actions
 
 Every single and bulk action funnels through **`POST /api/v1/dashboard/bulk-action`** →
-`BulkActionAlerts` (`dashboard_handlers.go:759`) → per-fingerprint `processAlertAction`.
+`BulkActionAlerts` (`dashboard_handlers.go:759`) → per-fingerprint `processAlertAction`. The
+response's top-level `success` reflects `FailedCount == 0` — a partial failure returns HTTP 200
+with `success: false` and a per-target `failures: [{target, kind, error}]` list, not a hardcoded
+`true` with the errors buried in an ignored `errors` field.
 
 | Action | Path |
 |--------|------|
@@ -160,7 +169,11 @@ Silence/Unsilence, configurable per-user **annotation buttons**, Ack/Unack, "Sou
   serializes search, all filter arrays, ack/comment filters, display/view mode, group-by, sort,
   page size, optionally column configs, and filter-scoped hides — into `FilterPresetData`. CRUD via
   `/api/v1/dashboard/filter-presets` (gRPC-backed), with shared-vs-personal (`is_shared`) and a
-  per-user default that loads at boot.
+  per-user default that loads at boot. **Editing a preset no longer overwrites its saved view by
+  default** — `buildPresetFilterData()`/`willReplaceSavedFilters()` keep the preset's own saved
+  filters (and column layout, unless opted in) unless the user explicitly checks "Replace this
+  preset's saved view"; only name/description/sharing and filter-scoped hides update otherwise.
+  Creating a new preset still always captures the live dashboard state.
 - **Resolved alerts view** (`displayMode==='resolved'`) is **not** from the cache — it queries the
   statistics subsystem (`POST /api/v1/statistics/recently-resolved`) and reconciles historical
   "resolved" against live cache status. Full detail in [statistics](statistics.md#recently-resolved).

--- a/openwiki/webui.md
+++ b/openwiki/webui.md
@@ -54,7 +54,14 @@ alerts** and the SSE hub:
   the in-memory `map[fingerprint]*DashboardAlert`, and normalizes upstream quirks
   (`suppressed`→`silenced`, `information`→`info`).
 - Tracks `UpdatedAt` only on *meaningful* change (`hasAlertChanged`) to avoid UI churn — this is
-  what `alert_cache_test.go` primarily verifies.
+  what `alert_cache_test.go` primarily verifies. The poll diff itself compares with the narrower
+  `hasPolledStateChanged` (state/summary/annotations only) instead, since a fresh poll result
+  carries no acknowledgement/comment state and comparing it against the enriched cache entry
+  would report a change every cycle for every acked or commented alert.
+- **SSE payloads carry the merged cache entry, not the raw poll result** — both the poll path and
+  `MutateAlert` (acks/comments/manual resolve) push a snapshot of the cache-resident alert, so
+  acknowledgement state survives the next SSE `update` instead of being clobbered by a
+  collaboration-blind poll.
 - Maintains a **per-user color cache** (rule-based alert coloring) refreshed after each poll.
 - On resolve, asynchronously archives the alert (with comments/acks) to the backend and fires
   `CaptureAlertFired`/`UpdateAlertResolved` statistics events.


### PR DESCRIPTION
Automated openwiki refresh covering:
feat(factory-tui): label legend overlay (press ?) with blocking labels and exact human action
fix(backend): require a real NOTIFICATOR_ENCRYPTION_KEY for Sentry token encryption (#110)
fix(backend): restrict RemoveAllResolvedAlerts to admins (#113)
fix(backend): a re-firing alert no longer inherits the previous incident's acknowledgement (#105)
fix(webui): keep saved filters intact when editing a filter preset (#98)
fix(webui): keep acknowledgement state in SSE alert updates (#104)
fix(dashboard): bulk-action failures are reported as success (#69)
fix(dashboard): client SSE merge ignores acknowledgement semantics (#120)

<!-- doc-agent -->