### PR TITLE
fix(webui): check Success flag in acknowledge and comment RPCs

### DIFF
--- a/internal/webui/client/backend_client.go
+++ b/internal/webui/client/backend_client.go
@@ -346,8 +346,14 @@ func (c *BackendClient) AddAcknowledgment(sessionID, alertKey, reason string) er
 		Reason:    reason,
 	}
 
-	_, err := c.alertClient.AddAcknowledgment(ctx, req)
-	return err
+	resp, err := c.alertClient.AddAcknowledgment(ctx, req)
+	if err != nil {
+		return err
+	}
+	if !resp.GetSuccess() {
+		return fmt.Errorf("%s", resp.GetMessage())
+	}
+	return nil
 }
 
 // DeleteAcknowledgment removes acknowledgment from an alert
@@ -364,8 +370,14 @@ func (c *BackendClient) DeleteAcknowledgment(sessionID, alertKey string) error {
 		AlertKey:  alertKey,
 	}
 
-	_, err := c.alertClient.DeleteAcknowledgment(ctx, req)
-	return err
+	resp, err := c.alertClient.DeleteAcknowledgment(ctx, req)
+	if err != nil {
+		return err
+	}
+	if !resp.GetSuccess() {
+		return fmt.Errorf("%s", resp.GetMessage())
+	}
+	return nil
 }
 
 // GetAcknowledgments retrieves acknowledgments for an alert
@@ -491,8 +503,14 @@ func (c *BackendClient) addComment(sessionID, alertKey, content, kind string) er
 		Kind:      kind,
 	}
 
-	_, err := c.alertClient.AddComment(ctx, req)
-	return err
+	resp, err := c.alertClient.AddComment(ctx, req)
+	if err != nil {
+		return err
+	}
+	if !resp.GetSuccess() {
+		return fmt.Errorf("%s", resp.GetMessage())
+	}
+	return nil
 }
 
 // DeleteComment removes a comment from an alert
@@ -509,8 +527,14 @@ func (c *BackendClient) DeleteComment(sessionID, commentID string) error {
 		CommentId: commentID,
 	}
 
-	_, err := c.alertClient.DeleteComment(ctx, req)
-	return err
+	resp, err := c.alertClient.DeleteComment(ctx, req)
+	if err != nil {
+		return err
+	}
+	if !resp.GetSuccess() {
+		return fmt.Errorf("%s", resp.GetMessage())
+	}
+	return nil
 }
 
 // GetRecentActivity fetches recent cross-alert collaboration events for the activity feed.

--- a/internal/webui/client/backend_client_test.go
+++ b/internal/webui/client/backend_client_test.go
@@ -1,0 +1,94 @@
+package client
+
+import (
+	"context"
+	"testing"
+
+	alertpb "notificator/internal/backend/proto/alert"
+
+	"google.golang.org/grpc"
+)
+
+// fakeAlertClient embeds the real interface (nil) so it satisfies
+// alertpb.AlertServiceClient while only overriding the methods under test.
+type fakeAlertClient struct {
+	alertpb.AlertServiceClient
+	success bool
+	message string
+}
+
+func (f *fakeAlertClient) AddAcknowledgment(ctx context.Context, in *alertpb.AddAcknowledgmentRequest, opts ...grpc.CallOption) (*alertpb.AddAcknowledgmentResponse, error) {
+	return &alertpb.AddAcknowledgmentResponse{Success: f.success, Message: f.message}, nil
+}
+
+func (f *fakeAlertClient) DeleteAcknowledgment(ctx context.Context, in *alertpb.DeleteAcknowledgmentRequest, opts ...grpc.CallOption) (*alertpb.DeleteAcknowledgmentResponse, error) {
+	return &alertpb.DeleteAcknowledgmentResponse{Success: f.success, Message: f.message}, nil
+}
+
+func (f *fakeAlertClient) AddComment(ctx context.Context, in *alertpb.AddCommentRequest, opts ...grpc.CallOption) (*alertpb.AddCommentResponse, error) {
+	return &alertpb.AddCommentResponse{Success: f.success, Message: f.message}, nil
+}
+
+func (f *fakeAlertClient) DeleteComment(ctx context.Context, in *alertpb.DeleteCommentRequest, opts ...grpc.CallOption) (*alertpb.DeleteCommentResponse, error) {
+	return &alertpb.DeleteCommentResponse{Success: f.success, Message: f.message}, nil
+}
+
+func TestAddAcknowledgment_BackendRejection(t *testing.T) {
+	c := &BackendClient{alertClient: &fakeAlertClient{success: false, message: "invalid session"}}
+	err := c.AddAcknowledgment("session", "alert-key", "reason")
+	if err == nil || err.Error() != "invalid session" {
+		t.Fatalf("expected error %q, got %v", "invalid session", err)
+	}
+}
+
+func TestAddAcknowledgment_Success(t *testing.T) {
+	c := &BackendClient{alertClient: &fakeAlertClient{success: true}}
+	if err := c.AddAcknowledgment("session", "alert-key", "reason"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeleteAcknowledgment_BackendRejection(t *testing.T) {
+	c := &BackendClient{alertClient: &fakeAlertClient{success: false, message: "unauthorized"}}
+	err := c.DeleteAcknowledgment("session", "alert-key")
+	if err == nil || err.Error() != "unauthorized" {
+		t.Fatalf("expected error %q, got %v", "unauthorized", err)
+	}
+}
+
+func TestDeleteAcknowledgment_Success(t *testing.T) {
+	c := &BackendClient{alertClient: &fakeAlertClient{success: true}}
+	if err := c.DeleteAcknowledgment("session", "alert-key"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAddComment_BackendRejection(t *testing.T) {
+	c := &BackendClient{alertClient: &fakeAlertClient{success: false, message: "Failed to create comment"}}
+	err := c.AddComment("session", "alert-key", "content")
+	if err == nil || err.Error() != "Failed to create comment" {
+		t.Fatalf("expected error %q, got %v", "Failed to create comment", err)
+	}
+}
+
+func TestAddComment_Success(t *testing.T) {
+	c := &BackendClient{alertClient: &fakeAlertClient{success: true}}
+	if err := c.AddComment("session", "alert-key", "content"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeleteComment_BackendRejection(t *testing.T) {
+	c := &BackendClient{alertClient: &fakeAlertClient{success: false, message: "not found"}}
+	err := c.DeleteComment("session", "comment-id")
+	if err == nil || err.Error() != "not found" {
+		t.Fatalf("expected error %q, got %v", "not found", err)
+	}
+}
+
+func TestDeleteComment_Success(t *testing.T) {
+	c := &BackendClient{alertClient: &fakeAlertClient{success: true}}
+	if err := c.DeleteComment("session", "comment-id"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

`AddAcknowledgment`, `DeleteAcknowledgment`, `AddComment` and `DeleteComment` in `internal/webui/client/backend_client.go` discarded the gRPC response and only checked the transport error:

```go
_, err := c.alertClient.AddAcknowledgment(ctx, req)
return err
```

The backend signals business-level failures (invalid session, DB write failure, unauthorized) in-band: it returns a gRPC-OK response carrying `Success: false` plus a `Message` (see `internal/backend/services/services.go` `AddComment`/`AddAcknowledgment`). Because the wrappers ignored `Success`, a rejected write was reported back to the caller as `nil` error — an acknowledged alert could silently revert ten seconds later with no explanation, and a posted comment could be lost while the UI showed a 200 OK.

This was inconsistent with the file's own convention — neighbours like `UpdateTimezone` already check `if !resp.Success { return fmt.Errorf(...) }`.

## Fix

Made the four wrappers check `resp.GetSuccess()` and surface `resp.GetMessage()` as an error, matching the existing pattern in the file. No handler changes were needed — `dashboard_handlers.go` already returns a non-nil error correctly wherever these wrappers are called, including in `processAlertAction`, so bulk-action `FailedCount` accounting now correctly reflects backend rejections.

## Testing

Added `internal/webui/client/backend_client_test.go` with a fake `AlertServiceClient` (embedding the real interface with only the four methods under test overridden) covering success and `Success: false` rejection paths for all four wrappers.

- `go build ./...`
- `go vet ./...`
- `go test ./internal/webui/client/...` — 8 passed

Closes #128

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>