### PR TITLE
docs(wiki): sync with recent changes

### DIFF
--- a/openwiki/.last-update.json
+++ b/openwiki/.last-update.json
@@ -1,6 +1,6 @@
 {
-  "updatedAt": "2026-07-27T05:32:37.000Z",
+  "updatedAt": "2026-07-30T11:59:34.000Z",
   "command": "update",
-  "gitHead": "7535af3a6491053216864e226841787166ceee43",
+  "gitHead": "d42d5da822f8884921b0ea9852d653bda47a3158",
   "model": "claude-sonnet-5"
 }

--- a/openwiki/dashboard.md
+++ b/openwiki/dashboard.md
@@ -144,6 +144,37 @@ with `success: false` and a per-target `failures: [{target, kind, error}]` list,
 > `updateActiveFilterPreset()`. Comment/ack counts on rows are maintained by incrementing
 > `alert.CommentCount` in the cache, not re-queried.
 
+### Silences page {#silences}
+
+`/silences` (`Silences.templ`, `handlers/silence_handlers.go`) is a dedicated silence
+management page, separate from the dashboard's quick Silence/Unsilence action:
+
+- **Advanced creation modal**: dynamic matcher rows (`=`, `!=`, `=~`, `!~`) with label
+  autocomplete and paste-to-import; per-source checkboxes to fan the silence out to a subset of
+  configured Alertmanagers (`POST /api/v1/dashboard/silences` → `fanOutSilence`, per-source
+  success/failure); a debounced live preview (`POST /api/v1/dashboard/silences/preview`) showing
+  match count and a capped alert sample before submitting; duration via presets (now `1h`–`90d`,
+  including `14d`/`30d`/`90d`), free-form (`parseExtendedDuration`, e.g. `2w`), or an absolute end
+  time; and a "Duplicate" action on any existing row (including expired ones) that prefills the
+  modal.
+- **Creator attribution**: silences created through notificator record the effective **username**
+  (not the internal user ID — a prior bug displayed raw IDs). Silences created outside notificator
+  (amtool, Alertmanager UI, karma) carry no origin metadata; the backend `ResolveSilenceCreators`
+  RPC matches `createdBy` against known users by ID/username/email and the page tags each row
+  either with the resolved username (a "notificator" badge) or a gray "external" badge when no
+  match is found.
+
+### Team activity feed {#activity-feed}
+
+`/activity` (`Activity.templ`, `handlers/activity_handlers.go`) is a cross-alert log of
+collaboration events — comments, acks/unacks, silences, resolves — sourced from the backend's
+`GetRecentActivity` RPC (session-gated, hard 200-row limit) via `GET /api/v1/dashboard/activity`.
+Query params: `windowMinutes` (default 60, unbounded upper end — actual size still capped by the
+backend), `scope=mine`, `kinds`, plus the shared dashboard filters (search, alertmanagers,
+severities, teams, alert names). The page polls every 30s **only while visible** — no SSE. Each
+event carries a `Kind` (`comment | ack | unack | silence | resolve`) recorded directly by the
+comment/audit write sites; a `comments.Kind` column and a `comments.created_at` index back this.
+
 ## Alert detail modal
 
 `AlertDetailsModal` (`components/modal_components.templ:921`), opened by
@@ -156,9 +187,19 @@ connected, its comments and acknowledgments.
 Tabs: **Overview**, **Details** (fingerprint, generator URL), **Labels** / **Annotations**
 (copy-to-clipboard), **Acknowledgments**, **Comments** (add/delete; system comments show a badge),
 **History** (lazy `GET /alert/:fp/history` → up to 50 fire/resolve/ack occurrences with MTTR/MTTA),
-and **Sentry** (only if the alert carries a `sentry` annotation/label; lazy-loaded). Header offers
-Silence/Unsilence, configurable per-user **annotation buttons**, Ack/Unack, "Source"
-(`generatorURL`), and "Copy as Issue" (builds a Markdown issue and copies it).
+and **Sentry** (only if the alert carries a `sentry` annotation/label; lazy-loaded — the target
+host is validated against the configured `sentry.base_url` and a mismatch is rejected rather than
+fetched, see [Sentry SSRF fix](#gotchas)). Header offers Silence/Unsilence, configurable per-user
+**annotation buttons**, Ack/Unack, "Source" (`generatorURL`), "Copy as Issue" (builds a Markdown
+issue and copies it), and **"Copy link"** (`copyAlertLink()`, `dashboard_modal.templ:128` — copies
+the same `/dashboard/alert/:fingerprint` deep-link URL used for `pushState`, with a 2s confirmation
+toast).
+
+The **History** tab's data also feeds a client-only **30-day frequency sparkline**
+(`computeSparkline()`, `dashboard_modal.templ:627`): a pure-JS histogram over the already
+lazy-loaded history entries bucketed into 30 daily bins, showing total occurrences (capped at the
+history endpoint's 50-entry limit, shown as "≥N"), and a week-over-week trend arrow. No new
+endpoint or charting library.
 
 > ⚠️ The modal's `Silences` field is **always empty** (`dashboard_handlers.go:1289`, not
 > implemented) — only `status.silencedBy` IDs are available.
@@ -190,6 +231,12 @@ dismissible banner prompts for browser-notification permission. Full behavior in
 [notifications](notifications.md).
 
 ## Gotchas {#gotchas}
+
+- **Sentry host validation (fixed SSRF-ish token leak):** the Sentry tab used to parse whatever
+  host appeared in an alert's `sentry` annotation/label — attacker-controlled Alertmanager payload
+  — and send the viewing user's personal/global Sentry token to it. `sentry_service.go` now
+  rejects any URL whose scheme+host doesn't exactly match the configured `sentry.base_url`
+  before building the request.
 
 - **`alertMatchesFilters()` (client) must mirror `applyDashboardFilters()` (server)** — or live
   updates go stale for the unmirrored filter. This is the #1 dashboard footgun.

--- a/openwiki/dashboard.md
+++ b/openwiki/dashboard.md
@@ -153,10 +153,10 @@ management page, separate from the dashboard's quick Silence/Unsilence action:
   autocomplete and paste-to-import; per-source checkboxes to fan the silence out to a subset of
   configured Alertmanagers (`POST /api/v1/dashboard/silences` → `fanOutSilence`, per-source
   success/failure); a debounced live preview (`POST /api/v1/dashboard/silences/preview`) showing
-  match count and a capped alert sample before submitting; duration via presets (now `1h`–`90d`,
-  including `14d`/`30d`/`90d`), free-form (`parseExtendedDuration`, e.g. `2w`), or an absolute end
-  time; and a "Duplicate" action on any existing row (including expired ones) that prefills the
-  modal.
+  match count and a capped alert sample before submitting; duration via presets (`1h`/`4h`/`24h`/`7d`),
+  free-form (`parseExtendedDuration`, e.g. `2w`), or an absolute end time; and a "Duplicate" action
+  on any existing row (including expired ones) that prefills the modal. (The dashboard's quick
+  `SilenceModal()` offers a wider `1h`–`90d` preset range, including `14d`/`30d`/`90d`.)
 - **Creator attribution**: silences created through notificator record the effective **username**
   (not the internal user ID — a prior bug displayed raw IDs). Silences created outside notificator
   (amtool, Alertmanager UI, karma) carry no origin metadata; the backend `ResolveSilenceCreators`
@@ -192,8 +192,8 @@ host is validated against the configured `sentry.base_url` and a mismatch is rej
 fetched, see [Sentry SSRF fix](#gotchas)). Header offers Silence/Unsilence, configurable per-user
 **annotation buttons**, Ack/Unack, "Source" (`generatorURL`), "Copy as Issue" (builds a Markdown
 issue and copies it), and **"Copy link"** (`copyAlertLink()`, `dashboard_modal.templ:128` — copies
-the same `/dashboard/alert/:fingerprint` deep-link URL used for `pushState`, with a 2s confirmation
-toast).
+the same `/dashboard/alert/:fingerprint` deep-link URL used for `pushState`, with a 2s inline
+checkmark icon swap on the button itself).
 
 The **History** tab's data also feeds a client-only **30-day frequency sparkline**
 (`computeSparkline()`, `dashboard_modal.templ:627`): a pure-JS histogram over the already

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -78,7 +78,8 @@ persistent (users, comments, acks, resolved-alert history, statistics, preferenc
 - [Architecture](architecture.md) — components, ports, request flow, real-time, build variants
 - [Backend](backend.md) — gRPC services, auth/sessions, database, statistics engine
 - [WebUI](webui.md) — routing, templ/HTMX/Alpine, SSE, auth, dashboards
-- [Live dashboard](dashboard.md) — the alert table: SSE merge, filters, actions, columns, modal
+- [Live dashboard](dashboard.md) — the alert table: SSE merge, filters, actions, columns, modal,
+  the [Silences page](dashboard.md#silences) and [team activity feed](dashboard.md#activity-feed)
 - [Statistics dashboard](statistics.md) — analytics: time ranges, on-call filtering, charts, saved views
 - [Notification system](notifications.md) — browser notifications + sound (and the dead desktop notifier)
 - [Domain concepts](domain.md) — alerts, fingerprints, acks/comments, resolved alerts, on-call rules

--- a/openwiki/webui.md
+++ b/openwiki/webui.md
@@ -63,6 +63,11 @@ alerts** and the SSE hub:
   acknowledgement state survives the next SSE `update` instead of being clobbered by a
   collaboration-blind poll.
 - Maintains a **per-user color cache** (rule-based alert coloring) refreshed after each poll.
+- `loadCommentCountsEfficiently` batch-refreshes `CommentCount` from the backend
+  (`GetCommentCountsBatch`). A backend-side DB failure now returns a gRPC error instead of an
+  empty map — the cache keeps last-known counts and retries next cycle, instead of the old
+  behavior of treating an empty map as authoritative and zeroing every row's badge for all
+  connected browsers.
 - On resolve, asynchronously archives the alert (with comments/acks) to the backend and fires
   `CaptureAlertFired`/`UpdateAlertResolved` statistics events.
 - **SSE fan-out:** `Subscribe`/`Unsubscribe`/`notifySubscribers` push buffered (10),
@@ -76,6 +81,8 @@ This is separate from the backend's gRPC collaboration stream — see
 ## Handlers (by feature)
 
 `internal/webui/handlers/`: `dashboard_handlers` (live dashboard + bulk actions),
+`silence_handlers` (silence CRUD + preview + creator/origin tagging),
+`activity_handlers` (team activity feed, `GET /api/v1/dashboard/activity`),
 `statistics_handlers` + `statistics_view_handlers` (analytics + saved views),
 `oauth_handlers`, `profile_handlers`, `notification_handlers`, `hidden_alerts_handlers`,
 `filter_preset_handlers`, `impersonation_handlers`, `sentry_handlers`, `sse_handler`,
@@ -90,7 +97,9 @@ This is separate from the backend's gRPC collaboration stream — see
 - `pages/` — `NewDashboard` (the **live operational dashboard**, `/dashboard` — deep-dived in
   [dashboard](dashboard.md)), `StatisticsDashboard` (the **historical analytics dashboard**,
   `/statistics` — deep-dived in [statistics](statistics.md)), `Login`, `Register`, `Profile`,
-  `OAuthCallback`, `Index`, `Playground` (dev/demo landing when `WebUI.Playground` is on).
+  `OAuthCallback`, `Index`, `Playground` (dev/demo landing when `WebUI.Playground` is on),
+  `Silences` (`/silences` — creation/preview/extend/expire), `Activity` (`/activity` — the
+  cross-alert team activity feed, see [dashboard](dashboard.md#activity-feed)).
   Browser/sound alerts are covered in [notifications](notifications.md).
 - `components/` — tables, modals, filter/group views, timezone selector, page navigator, etc.
 - `scripts/` — **`.templ` files whose entire body is a `<script>` of hand-written Alpine.js**


### PR DESCRIPTION
Automated openwiki refresh covering:
feat(factory-tui): add factory.py, a modern Textual control room
feat(factory-tui): live agent view, titled pipeline tables
fix(backend): make CaptureAlertFired idempotent, stop 23505 log flood
fix(webui): record username instead of user ID as silence creator
feat(silences): tag external silences and resolve creator IDs to usernames
feat(factory-tui): unblock parked loops from the Loops page
feat(silences): advanced silence creation modal (#130) (#132)
fix(webui): restrict Sentry requests to the configured instance host
fix(collab): surface comment-count batch failures instead of wiping badges
feat(webui): extend silence duration presets to 14d, 30d and 90d
fix(webui): use errors.New for backend error strings flagged by vet
feat(dashboard): team activity feed — cross-alert log of acks, comments, silences and resolves (#77) (#136)
feat: ENC KEy
feat(webui): alert modal copy link and 30-day frequency sparkline (#137)

<!-- doc-agent -->