### PR TITLE
fix(security): stop shipping a public encryption key in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,8 @@ services:
       - NOTIFICATOR_BACKEND_DATABASE_USER=notificator
       - NOTIFICATOR_BACKEND_DATABASE_PASSWORD=notificator_password
       - NOTIFICATOR_BACKEND_DATABASE_SSL_MODE=disable
-      - NOTIFICATOR_ENCRYPTION_KEY=51f64f844ed0a772d10c2184b02a682ab6b5348f50181a9faaaecfb1446c8dcf
+      # dev-only key — generate your own: openssl rand -hex 32
+      - NOTIFICATOR_ENCRYPTION_KEY=${NOTIFICATOR_ENCRYPTION_KEY:-badbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadb}
 
       # Alertmanager configuration
       - NOTIFICATOR_ALERTMANAGERS_0_NAME=Fake Alertmanager

--- a/internal/backend/database/sentry_db.go
+++ b/internal/backend/database/sentry_db.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"log"
 	"os"
 
 	"notificator/internal/backend/models"
@@ -17,12 +18,24 @@ import (
 // used to encrypt Sentry personal tokens at rest.
 const EncryptionKeyEnvVar = "NOTIFICATOR_ENCRYPTION_KEY"
 
+// devDefaultEncryptionKey is the placeholder key shipped in docker-compose.yml
+// for zero-friction local dev/test. It must never be used in production.
+const devDefaultEncryptionKey = "badbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadb"
+
 // ValidateEncryptionKey checks that NOTIFICATOR_ENCRYPTION_KEY is set to 64
 // lowercase hex characters (32 raw bytes), returning an error naming the
-// variable and the generation command otherwise.
+// variable and the generation command otherwise. It also warns loudly when
+// the key matches the known dev default, since that means a deployment is
+// running with a publicly-known, non-secret encryption key.
 func ValidateEncryptionKey() error {
 	_, err := encryptionKeyFromEnv()
-	return err
+	if err != nil {
+		return err
+	}
+	if os.Getenv(EncryptionKeyEnvVar) == devDefaultEncryptionKey {
+		log.Printf("WARNING: %s is set to the known dev/test default from docker-compose.yml. This key is public and MUST NOT be used to protect real secrets — generate your own with `openssl rand -hex 32`.", EncryptionKeyEnvVar)
+	}
+	return nil
 }
 
 func encryptionKeyFromEnv() ([]byte, error) {

--- a/internal/backend/database/sentry_db_test.go
+++ b/internal/backend/database/sentry_db_test.go
@@ -1,6 +1,12 @@
 package database
 
-import "testing"
+import (
+	"bytes"
+	"log"
+	"os"
+	"strings"
+	"testing"
+)
 
 func TestValidateEncryptionKey(t *testing.T) {
 	cases := map[string]struct {
@@ -26,6 +32,21 @@ func TestValidateEncryptionKey(t *testing.T) {
 				t.Fatalf("expected no error for key %q, got %v", tc.key, err)
 			}
 		})
+	}
+}
+
+func TestValidateEncryptionKeyWarnsOnDevDefault(t *testing.T) {
+	t.Setenv(EncryptionKeyEnvVar, devDefaultEncryptionKey)
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+
+	if err := ValidateEncryptionKey(); err != nil {
+		t.Fatalf("expected no error for dev default key, got %v", err)
+	}
+	if !strings.Contains(buf.String(), "WARNING") {
+		t.Fatalf("expected a startup warning for the dev default key, got log output: %q", buf.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- `docker-compose.yml` shipped a literal, valid 64-hex-char AES-256 key for `NOTIFICATOR_ENCRYPTION_KEY` (added in 46b9db6 to satisfy the #110/#113 boot-time validation). Because it's committed to git history, that key is public — copying the compose file into a real deployment gives a false sense of security while Sentry tokens end up encrypted with a known key.
- The line now reads `NOTIFICATOR_ENCRYPTION_KEY=${NOTIFICATOR_ENCRYPTION_KEY:-badbad...badb}` — a 64-hex-char default that's obviously fake (repeating `bad` pattern, not random-looking), still overridable via env, with a comment pointing at `openssl rand -hex 32` for real deployments.
- `ValidateEncryptionKey` (`internal/backend/database/sentry_db.go`) now logs a loud `WARNING` at startup when the running key matches this known dev default, so a copy-pasted compose file announces itself in prod logs instead of silently "passing" the #110 check.
- Helm chart values were already placeholder-only (`charts/notificator-app/values.yaml:61`) — no change needed there.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/backend/database/...`
- [x] `go test ./internal/backend/database/...` (existing `TestValidateEncryptionKey`/`TestEncryptDecryptRoundTrip` + new `TestValidateEncryptionKeyWarnsOnDevDefault`)
- [x] `docker compose -f docker-compose.yml config` resolves `NOTIFICATOR_ENCRYPTION_KEY` to the 64-char dev default when unset, confirming `make test` / `docker-compose up -d` still boot with zero manual env setup

Closes #141

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>