### PR TITLE
fix(backend): require session validation on GetUserGroups, SyncUserGroups and GetUserSentryConfig

### DIFF
--- a/internal/backend/proto/auth/auth.pb.go
+++ b/internal/backend/proto/auth/auth.pb.go
@@ -1562,6 +1562,7 @@ func (x *OAuthProvider) GetEnabled() bool {
 type GetUserGroupsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	SessionId     string                 `protobuf:"bytes,2,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"` // Required for authorization
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1599,6 +1600,13 @@ func (*GetUserGroupsRequest) Descriptor() ([]byte, []int) {
 func (x *GetUserGroupsRequest) GetUserId() string {
 	if x != nil {
 		return x.UserId
+	}
+	return ""
+}
+
+func (x *GetUserGroupsRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
 	}
 	return ""
 }
@@ -1735,6 +1743,7 @@ type SyncUserGroupsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
 	Provider      string                 `protobuf:"bytes,2,opt,name=provider,proto3" json:"provider,omitempty"`
+	SessionId     string                 `protobuf:"bytes,3,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"` // Required for authorization
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1779,6 +1788,13 @@ func (x *SyncUserGroupsRequest) GetUserId() string {
 func (x *SyncUserGroupsRequest) GetProvider() string {
 	if x != nil {
 		return x.Provider
+	}
+	return ""
+}
+
+func (x *SyncUserGroupsRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
 	}
 	return ""
 }
@@ -1847,6 +1863,7 @@ func (x *SyncUserGroupsResponse) GetGroupsSynced() int32 {
 type GetUserSentryConfigRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	SessionId     string                 `protobuf:"bytes,2,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"` // Required for authorization
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1884,6 +1901,13 @@ func (*GetUserSentryConfigRequest) Descriptor() ([]byte, []int) {
 func (x *GetUserSentryConfigRequest) GetUserId() string {
 	if x != nil {
 		return x.UserId
+	}
+	return ""
+}
+
+func (x *GetUserSentryConfigRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
 	}
 	return ""
 }
@@ -2665,9 +2689,11 @@ const file_proto_auth_proto_rawDesc = "" +
 	"\rOAuthProvider\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12!\n" +
 	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\x12\x18\n" +
-	"\aenabled\x18\x03 \x01(\bR\aenabled\"/\n" +
+	"\aenabled\x18\x03 \x01(\bR\aenabled\"N\n" +
 	"\x14GetUserGroupsRequest\x12\x17\n" +
-	"\auser_id\x18\x01 \x01(\tR\x06userId\"L\n" +
+	"\auser_id\x18\x01 \x01(\tR\x06userId\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x02 \x01(\tR\tsessionId\"L\n" +
 	"\x15GetUserGroupsResponse\x123\n" +
 	"\x06groups\x18\x01 \x03(\v2\x1b.notificator.auth.UserGroupR\x06groups\"\x95\x01\n" +
 	"\tUserGroup\x12\x0e\n" +
@@ -2676,16 +2702,20 @@ const file_proto_auth_proto_rawDesc = "" +
 	"\bprovider\x18\x03 \x01(\tR\bprovider\x12\x12\n" +
 	"\x04type\x18\x04 \x01(\tR\x04type\x12\x12\n" +
 	"\x04role\x18\x05 \x01(\tR\x04role\x12 \n" +
-	"\vpermissions\x18\x06 \x01(\tR\vpermissions\"L\n" +
+	"\vpermissions\x18\x06 \x01(\tR\vpermissions\"k\n" +
 	"\x15SyncUserGroupsRequest\x12\x17\n" +
 	"\auser_id\x18\x01 \x01(\tR\x06userId\x12\x1a\n" +
-	"\bprovider\x18\x02 \x01(\tR\bprovider\"m\n" +
+	"\bprovider\x18\x02 \x01(\tR\bprovider\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x03 \x01(\tR\tsessionId\"m\n" +
 	"\x16SyncUserGroupsResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x14\n" +
 	"\x05error\x18\x02 \x01(\tR\x05error\x12#\n" +
-	"\rgroups_synced\x18\x03 \x01(\x05R\fgroupsSynced\"5\n" +
+	"\rgroups_synced\x18\x03 \x01(\x05R\fgroupsSynced\"T\n" +
 	"\x1aGetUserSentryConfigRequest\x12\x17\n" +
-	"\auser_id\x18\x01 \x01(\tR\x06userId\"\x89\x01\n" +
+	"\auser_id\x18\x01 \x01(\tR\x06userId\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x02 \x01(\tR\tsessionId\"\x89\x01\n" +
 	"\x1bGetUserSentryConfigResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x14\n" +
 	"\x05error\x18\x02 \x01(\tR\x05error\x12:\n" +

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -127,7 +127,7 @@ func (s *Server) initServices() {
 		log.Printf("ℹ️  OAuth is not enabled in configuration")
 	}
 
-	s.authService = services.NewAuthServiceGorm(s.db, s.oauthService)
+	s.authService = services.NewAuthServiceGorm(s.db, s.oauthService, &s.config.Admin)
 	s.alertService = services.NewAlertServiceGorm(s.db, &s.config.Admin)
 	s.statisticsService = services.NewStatisticsServiceGorm(s.db, &s.config.Admin)
 

--- a/internal/backend/services/auth_impersonation_test.go
+++ b/internal/backend/services/auth_impersonation_test.go
@@ -1,0 +1,258 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"notificator/config"
+	"notificator/internal/backend/database"
+	"notificator/internal/backend/models"
+	authpb "notificator/internal/backend/proto/auth"
+)
+
+func setupAuthServiceImpersonationTest(t *testing.T, allowedUsers []string) (*AuthServiceGorm, *database.GormDB, *models.User, *models.User) {
+	t.Helper()
+
+	t.Setenv(database.EncryptionKeyEnvVar, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+	db, err := database.NewGormDB("sqlite", config.DatabaseConfig{SQLitePath: t.TempDir() + "/test.db"})
+	if err != nil {
+		t.Fatalf("failed to create test database: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := db.AutoMigrate(); err != nil {
+		t.Fatalf("failed to migrate test database: %v", err)
+	}
+
+	victim, err := db.CreateUser("victim", "victim@example.com", "hash")
+	if err != nil {
+		t.Fatalf("failed to create victim: %v", err)
+	}
+	requester, err := db.CreateUser("requester", "requester@example.com", "hash")
+	if err != nil {
+		t.Fatalf("failed to create requester: %v", err)
+	}
+
+	if err := db.CreateSession(victim.ID, "victim-session", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("failed to create victim session: %v", err)
+	}
+	if err := db.CreateSession(requester.ID, "requester-session", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("failed to create requester session: %v", err)
+	}
+
+	svc := NewAuthServiceGorm(db, nil, &config.AdminConfig{ImpersonationAllowedUsers: allowedUsers})
+
+	return svc, db, victim, requester
+}
+
+// GetUserGroups
+
+func TestGetUserGroups_MissingSessionRejected(t *testing.T) {
+	svc, db, victim, _ := setupAuthServiceImpersonationTest(t, nil)
+	if err := db.SyncUserGroups(victim.ID, "github", []models.OAuthGroupInfo{{ID: "g1", Name: "victim-group", Type: "team"}}); err != nil {
+		t.Fatalf("failed to seed victim group: %v", err)
+	}
+
+	resp, err := svc.GetUserGroups(context.Background(), &authpb.GetUserGroupsRequest{UserId: victim.ID})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Groups) != 0 {
+		t.Fatalf("expected no groups without a session, got %d", len(resp.Groups))
+	}
+}
+
+func TestGetUserGroups_OrdinaryUserCannotImpersonate(t *testing.T) {
+	svc, db, victim, _ := setupAuthServiceImpersonationTest(t, nil)
+	if err := db.SyncUserGroups(victim.ID, "github", []models.OAuthGroupInfo{{ID: "g1", Name: "victim-group", Type: "team"}}); err != nil {
+		t.Fatalf("failed to seed victim group: %v", err)
+	}
+
+	resp, err := svc.GetUserGroups(context.Background(), &authpb.GetUserGroupsRequest{
+		SessionId: "requester-session",
+		UserId:    victim.ID,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Groups) != 0 {
+		t.Fatalf("expected victim's groups not to leak to unauthorized requester, got %d", len(resp.Groups))
+	}
+}
+
+func TestGetUserGroups_AllowlistedAdminCanImpersonate(t *testing.T) {
+	svc, db, victim, _ := setupAuthServiceImpersonationTest(t, []string{"requester"})
+	if err := db.SyncUserGroups(victim.ID, "github", []models.OAuthGroupInfo{{ID: "g1", Name: "victim-group", Type: "team"}}); err != nil {
+		t.Fatalf("failed to seed victim group: %v", err)
+	}
+
+	resp, err := svc.GetUserGroups(context.Background(), &authpb.GetUserGroupsRequest{
+		SessionId: "requester-session",
+		UserId:    victim.ID,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Groups) != 1 {
+		t.Fatalf("expected allowlisted admin to read victim's groups, got %d", len(resp.Groups))
+	}
+}
+
+func TestGetUserGroups_SelfAccessAllowed(t *testing.T) {
+	svc, db, _, requester := setupAuthServiceImpersonationTest(t, nil)
+	if err := db.SyncUserGroups(requester.ID, "github", []models.OAuthGroupInfo{{ID: "g1", Name: "own-group", Type: "team"}}); err != nil {
+		t.Fatalf("failed to seed requester group: %v", err)
+	}
+
+	resp, err := svc.GetUserGroups(context.Background(), &authpb.GetUserGroupsRequest{
+		SessionId: "requester-session",
+		UserId:    requester.ID,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Groups) != 1 {
+		t.Fatalf("expected requester to read their own groups, got %d", len(resp.Groups))
+	}
+}
+
+// GetUserSentryConfig
+
+func TestGetUserSentryConfig_MissingSessionRejected(t *testing.T) {
+	svc, db, victim, _ := setupAuthServiceImpersonationTest(t, nil)
+	if err := db.SaveUserSentryConfig(victim.ID, "victim-token", "https://sentry.io"); err != nil {
+		t.Fatalf("failed to seed victim sentry config: %v", err)
+	}
+
+	resp, err := svc.GetUserSentryConfig(context.Background(), &authpb.GetUserSentryConfigRequest{UserId: victim.ID})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Success || resp.Config != nil {
+		t.Fatalf("expected no config without a session, got success=%v config=%v", resp.Success, resp.Config)
+	}
+}
+
+func TestGetUserSentryConfig_OrdinaryUserCannotImpersonate(t *testing.T) {
+	svc, db, victim, _ := setupAuthServiceImpersonationTest(t, nil)
+	if err := db.SaveUserSentryConfig(victim.ID, "victim-token", "https://sentry.io"); err != nil {
+		t.Fatalf("failed to seed victim sentry config: %v", err)
+	}
+
+	resp, err := svc.GetUserSentryConfig(context.Background(), &authpb.GetUserSentryConfigRequest{
+		SessionId: "requester-session",
+		UserId:    victim.ID,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Success || resp.Config != nil {
+		t.Fatalf("expected victim's Sentry config not to leak to unauthorized requester, got success=%v config=%v", resp.Success, resp.Config)
+	}
+}
+
+func TestGetUserSentryConfig_AllowlistedAdminCanImpersonate(t *testing.T) {
+	svc, db, victim, _ := setupAuthServiceImpersonationTest(t, []string{"requester"})
+	if err := db.SaveUserSentryConfig(victim.ID, "victim-token", "https://sentry.io"); err != nil {
+		t.Fatalf("failed to seed victim sentry config: %v", err)
+	}
+
+	resp, err := svc.GetUserSentryConfig(context.Background(), &authpb.GetUserSentryConfigRequest{
+		SessionId: "requester-session",
+		UserId:    victim.ID,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Success || resp.Config == nil {
+		t.Fatalf("expected allowlisted admin to read victim's Sentry config, got success=%v config=%v", resp.Success, resp.Config)
+	}
+}
+
+func TestGetUserSentryConfig_SelfAccessAllowed(t *testing.T) {
+	svc, db, _, requester := setupAuthServiceImpersonationTest(t, nil)
+	if err := db.SaveUserSentryConfig(requester.ID, "own-token", "https://sentry.io"); err != nil {
+		t.Fatalf("failed to seed requester sentry config: %v", err)
+	}
+
+	resp, err := svc.GetUserSentryConfig(context.Background(), &authpb.GetUserSentryConfigRequest{
+		SessionId: "requester-session",
+		UserId:    requester.ID,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Success || resp.Config == nil {
+		t.Fatalf("expected requester to read their own Sentry config, got success=%v config=%v", resp.Success, resp.Config)
+	}
+}
+
+// SyncUserGroups: the OAuth service is nil in tests, so a request that clears
+// the authorization gate always fails afterward with "OAuth service not
+// configured" instead of the impersonation-denial error. That distinguishes
+// "authorization passed" from "authorization was denied" without needing a
+// live OAuth provider.
+
+func TestSyncUserGroups_MissingSessionRejected(t *testing.T) {
+	svc, _, victim, _ := setupAuthServiceImpersonationTest(t, nil)
+
+	resp, err := svc.SyncUserGroups(context.Background(), &authpb.SyncUserGroupsRequest{
+		UserId:   victim.ID,
+		Provider: "github",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Success || resp.Error != "Session ID is required" {
+		t.Fatalf("expected sync without a session to be rejected, got success=%v error=%q", resp.Success, resp.Error)
+	}
+}
+
+func TestSyncUserGroups_OrdinaryUserCannotImpersonate(t *testing.T) {
+	svc, _, victim, _ := setupAuthServiceImpersonationTest(t, nil)
+
+	resp, err := svc.SyncUserGroups(context.Background(), &authpb.SyncUserGroupsRequest{
+		SessionId: "requester-session",
+		UserId:    victim.ID,
+		Provider:  "github",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Success || resp.Error != "Not authorized to impersonate this user" {
+		t.Fatalf("expected sync of another user's groups to be denied, got success=%v error=%q", resp.Success, resp.Error)
+	}
+}
+
+func TestSyncUserGroups_AllowlistedAdminPassesAuthorization(t *testing.T) {
+	svc, _, victim, _ := setupAuthServiceImpersonationTest(t, []string{"requester"})
+
+	resp, err := svc.SyncUserGroups(context.Background(), &authpb.SyncUserGroupsRequest{
+		SessionId: "requester-session",
+		UserId:    victim.ID,
+		Provider:  "github",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Success || resp.Error != "OAuth service not configured" {
+		t.Fatalf("expected allowlisted admin to clear authorization and fail downstream, got success=%v error=%q", resp.Success, resp.Error)
+	}
+}
+
+func TestSyncUserGroups_SelfAccessPassesAuthorization(t *testing.T) {
+	svc, _, _, requester := setupAuthServiceImpersonationTest(t, nil)
+
+	resp, err := svc.SyncUserGroups(context.Background(), &authpb.SyncUserGroupsRequest{
+		SessionId: "requester-session",
+		UserId:    requester.ID,
+		Provider:  "github",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Success || resp.Error != "OAuth service not configured" {
+		t.Fatalf("expected self-sync to clear authorization and fail downstream, got success=%v error=%q", resp.Success, resp.Error)
+	}
+}

--- a/internal/backend/services/services.go
+++ b/internal/backend/services/services.go
@@ -30,12 +30,14 @@ type AuthServiceGorm struct {
 	authpb.UnimplementedAuthServiceServer
 	db           *database.GormDB
 	oauthService *OAuthService
+	adminConfig  *config.AdminConfig
 }
 
-func NewAuthServiceGorm(db *database.GormDB, oauthService *OAuthService) *AuthServiceGorm {
+func NewAuthServiceGorm(db *database.GormDB, oauthService *OAuthService, adminConfig *config.AdminConfig) *AuthServiceGorm {
 	return &AuthServiceGorm{
 		db:           db,
 		oauthService: oauthService,
+		adminConfig:  adminConfig,
 	}
 }
 
@@ -1771,16 +1773,30 @@ func (s *AuthServiceGorm) OAuthCallback(ctx context.Context, req *authpb.OAuthCa
 
 // GetUserGroups implements the GetUserGroups RPC method
 func (s *AuthServiceGorm) GetUserGroups(ctx context.Context, req *authpb.GetUserGroupsRequest) (*authpb.GetUserGroupsResponse, error) {
-	if req.UserId == "" {
+	if req.UserId == "" || req.SessionId == "" {
+		return &authpb.GetUserGroupsResponse{
+			Groups: []*authpb.UserGroup{},
+		}, nil
+	}
+
+	authenticatedUser, err := s.db.GetUserBySession(req.SessionId)
+	if err != nil {
+		return &authpb.GetUserGroupsResponse{
+			Groups: []*authpb.UserGroup{},
+		}, nil
+	}
+
+	targetUserID, err := resolveTargetUser(s.adminConfig, authenticatedUser, req.UserId, "GetUserGroups")
+	if err != nil {
 		return &authpb.GetUserGroupsResponse{
 			Groups: []*authpb.UserGroup{},
 		}, nil
 	}
 
 	// Get user groups from database
-	groups, err := s.db.GetUserGroups(req.UserId)
+	groups, err := s.db.GetUserGroups(targetUserID)
 	if err != nil {
-		log.Printf("Failed to get user groups for user %s: %v", req.UserId, err)
+		log.Printf("Failed to get user groups for user %s: %v", targetUserID, err)
 		return &authpb.GetUserGroupsResponse{
 			Groups: []*authpb.UserGroup{},
 		}, nil
@@ -1804,7 +1820,7 @@ func (s *AuthServiceGorm) GetUserGroups(ctx context.Context, req *authpb.GetUser
 		})
 	}
 
-	log.Printf("Retrieved %d groups for user %s", len(pbGroups), req.UserId)
+	log.Printf("Retrieved %d groups for user %s", len(pbGroups), targetUserID)
 	return &authpb.GetUserGroupsResponse{
 		Groups: pbGroups,
 	}, nil
@@ -1819,10 +1835,33 @@ func (s *AuthServiceGorm) SyncUserGroups(ctx context.Context, req *authpb.SyncUs
 		}, nil
 	}
 
+	if req.SessionId == "" {
+		return &authpb.SyncUserGroupsResponse{
+			Success: false,
+			Error:   "Session ID is required",
+		}, nil
+	}
+
 	if req.Provider == "" {
 		return &authpb.SyncUserGroupsResponse{
 			Success: false,
 			Error:   "Provider is required",
+		}, nil
+	}
+
+	authenticatedUser, err := s.db.GetUserBySession(req.SessionId)
+	if err != nil {
+		return &authpb.SyncUserGroupsResponse{
+			Success: false,
+			Error:   "Invalid session",
+		}, nil
+	}
+
+	targetUserID, err := resolveTargetUser(s.adminConfig, authenticatedUser, req.UserId, "SyncUserGroups")
+	if err != nil {
+		return &authpb.SyncUserGroupsResponse{
+			Success: false,
+			Error:   "Not authorized to impersonate this user",
 		}, nil
 	}
 
@@ -1836,9 +1875,9 @@ func (s *AuthServiceGorm) SyncUserGroups(ctx context.Context, req *authpb.SyncUs
 	}
 
 	// Get user by ID to verify it exists and get OAuth info
-	user, err := s.db.GetUserByID(req.UserId)
+	user, err := s.db.GetUserByID(targetUserID)
 	if err != nil {
-		log.Printf("Failed to get user %s for group sync: %v", req.UserId, err)
+		log.Printf("Failed to get user %s for group sync: %v", targetUserID, err)
 		return &authpb.SyncUserGroupsResponse{
 			Success: false,
 			Error:   "User not found",
@@ -1854,9 +1893,9 @@ func (s *AuthServiceGorm) SyncUserGroups(ctx context.Context, req *authpb.SyncUs
 	}
 
 	// Get the user's OAuth token for group sync
-	oauthToken, err := s.db.GetOAuthToken(req.UserId, req.Provider)
+	oauthToken, err := s.db.GetOAuthToken(targetUserID, req.Provider)
 	if err != nil {
-		log.Printf("Failed to get OAuth token for user %s: %v", req.UserId, err)
+		log.Printf("Failed to get OAuth token for user %s: %v", targetUserID, err)
 		return &authpb.SyncUserGroupsResponse{
 			Success: false,
 			Error:   "OAuth token not found or expired",
@@ -1883,7 +1922,7 @@ func (s *AuthServiceGorm) SyncUserGroups(ctx context.Context, req *authpb.SyncUs
 
 	// Sync groups to database
 	if len(userInfo.Groups) > 0 {
-		err = s.db.SyncUserGroups(req.UserId, req.Provider, userInfo.Groups)
+		err = s.db.SyncUserGroups(targetUserID, req.Provider, userInfo.Groups)
 		if err != nil {
 			log.Printf("Failed to sync user groups: %v", err)
 			return &authpb.SyncUserGroupsResponse{
@@ -1893,7 +1932,7 @@ func (s *AuthServiceGorm) SyncUserGroups(ctx context.Context, req *authpb.SyncUs
 		}
 	}
 
-	log.Printf("Successfully synced %d groups for user %s from provider %s", len(userInfo.Groups), req.UserId, req.Provider)
+	log.Printf("Successfully synced %d groups for user %s from provider %s", len(userInfo.Groups), targetUserID, req.Provider)
 	return &authpb.SyncUserGroupsResponse{
 		Success:      true,
 		GroupsSynced: int32(len(userInfo.Groups)),
@@ -2269,8 +2308,31 @@ func (s *AuthServiceGorm) GetUserSentryConfig(ctx context.Context, req *authpb.G
 		}, nil
 	}
 
+	if req.SessionId == "" {
+		return &authpb.GetUserSentryConfigResponse{
+			Success: false,
+			Error:   "Session ID is required",
+		}, nil
+	}
+
+	authenticatedUser, err := s.db.GetUserBySession(req.SessionId)
+	if err != nil {
+		return &authpb.GetUserSentryConfigResponse{
+			Success: false,
+			Error:   "Invalid session",
+		}, nil
+	}
+
+	targetUserID, err := resolveTargetUser(s.adminConfig, authenticatedUser, req.UserId, "GetUserSentryConfig")
+	if err != nil {
+		return &authpb.GetUserSentryConfigResponse{
+			Success: false,
+			Error:   "Not authorized to impersonate this user",
+		}, nil
+	}
+
 	// Get user Sentry config from database using string user ID
-	config, err := s.db.GetUserSentryConfig(req.UserId)
+	config, err := s.db.GetUserSentryConfig(targetUserID)
 	if err != nil {
 		// Config not found is not an error, just return empty config
 		return &authpb.GetUserSentryConfigResponse{
@@ -2281,7 +2343,7 @@ func (s *AuthServiceGorm) GetUserSentryConfig(ctx context.Context, req *authpb.G
 
 	// Convert to protobuf format (excluding sensitive token)
 	pbConfig := &authpb.UserSentryConfig{
-		UserId:    req.UserId,
+		UserId:    targetUserID,
 		BaseUrl:   config.SentryBaseURL,
 		CreatedAt: timestamppb.New(config.CreatedAt),
 		UpdatedAt: timestamppb.New(config.UpdatedAt),

--- a/internal/backend/services/update_timezone_test.go
+++ b/internal/backend/services/update_timezone_test.go
@@ -31,7 +31,7 @@ func setupAuthServiceWithSession(t *testing.T) (*AuthServiceGorm, string) {
 		t.Fatalf("failed to create session: %v", err)
 	}
 
-	return NewAuthServiceGorm(db, nil), sessionID
+	return NewAuthServiceGorm(db, nil, nil), sessionID
 }
 
 func TestUpdateTimezone(t *testing.T) {

--- a/internal/webui/client/backend_client.go
+++ b/internal/webui/client/backend_client.go
@@ -939,7 +939,7 @@ func (c *BackendClient) GetOAuthConfig() (map[string]interface{}, error) {
 }
 
 // GetUserGroups retrieves user groups
-func (c *BackendClient) GetUserGroups(userID string) ([]map[string]interface{}, error) {
+func (c *BackendClient) GetUserGroups(userID, sessionID string) ([]map[string]interface{}, error) {
 	if c.authClient == nil {
 		return nil, fmt.Errorf("not connected to backend")
 	}
@@ -948,7 +948,8 @@ func (c *BackendClient) GetUserGroups(userID string) ([]map[string]interface{}, 
 	defer cancel()
 
 	req := &authpb.GetUserGroupsRequest{
-		UserId: userID,
+		UserId:    userID,
+		SessionId: sessionID,
 	}
 
 	resp, err := c.authClient.GetUserGroups(ctx, req)
@@ -970,7 +971,7 @@ func (c *BackendClient) GetUserGroups(userID string) ([]map[string]interface{}, 
 }
 
 // SyncUserGroups synchronizes user groups with OAuth provider
-func (c *BackendClient) SyncUserGroups(userID, provider string) error {
+func (c *BackendClient) SyncUserGroups(userID, provider, sessionID string) error {
 	if c.authClient == nil {
 		return fmt.Errorf("not connected to backend")
 	}
@@ -979,8 +980,9 @@ func (c *BackendClient) SyncUserGroups(userID, provider string) error {
 	defer cancel()
 
 	req := &authpb.SyncUserGroupsRequest{
-		UserId:   userID,
-		Provider: provider,
+		UserId:    userID,
+		Provider:  provider,
+		SessionId: sessionID,
 	}
 
 	resp, err := c.authClient.SyncUserGroups(ctx, req)
@@ -1291,7 +1293,7 @@ type SentryConfig struct {
 }
 
 // GetUserSentryConfig retrieves a user's Sentry configuration
-func (c *BackendClient) GetUserSentryConfig(userID string) (*SentryConfig, error) {
+func (c *BackendClient) GetUserSentryConfig(userID, sessionID string) (*SentryConfig, error) {
 	if c.authClient == nil {
 		return nil, fmt.Errorf("not connected to backend")
 	}
@@ -1300,7 +1302,8 @@ func (c *BackendClient) GetUserSentryConfig(userID string) (*SentryConfig, error
 	defer cancel()
 
 	req := &authpb.GetUserSentryConfigRequest{
-		UserId: userID,
+		UserId:    userID,
+		SessionId: sessionID,
 	}
 
 	resp, err := c.authClient.GetUserSentryConfig(ctx, req)

--- a/internal/webui/handlers/oauth_handlers.go
+++ b/internal/webui/handlers/oauth_handlers.go
@@ -240,7 +240,7 @@ func GetUserGroups(c *gin.Context) {
 		return
 	}
 
-	groups, err := backendClient.GetUserGroups(user.ID)
+	groups, err := backendClient.GetUserGroups(user.ID, middleware.GetSessionIDFromContext(c))
 	if err != nil {
 		log.Printf("Failed to get user groups: %v", err)
 		c.JSON(http.StatusInternalServerError, models.ErrorResponse("Failed to retrieve user groups"))
@@ -271,7 +271,7 @@ func SyncUserGroups(c *gin.Context) {
 	}
 
 	provider := *user.OAuthProvider
-	err := backendClient.SyncUserGroups(user.ID, provider)
+	err := backendClient.SyncUserGroups(user.ID, provider, middleware.GetSessionIDFromContext(c))
 	if err != nil {
 		log.Printf("Failed to sync user groups: %v", err)
 		logOAuthActivity(&user.ID, provider, "group_sync_failed", false, err.Error(), getClientIP(c), c.GetHeader("User-Agent"))

--- a/internal/webui/handlers/sentry_handlers.go
+++ b/internal/webui/handlers/sentry_handlers.go
@@ -85,6 +85,7 @@ func GetUserSentryConfig(c *gin.Context) {
 	}
 
 	userID := user.ID
+	sessionID := middleware.GetSessionIDFromContext(c)
 
 	// For now, return a simple response - in real implementation,
 	// we would check the database via backend client
@@ -95,7 +96,7 @@ func GetUserSentryConfig(c *gin.Context) {
 	}
 
 	// Call backend to get Sentry config
-	config, err := backendClient.GetUserSentryConfig(userID)
+	config, err := backendClient.GetUserSentryConfig(userID, sessionID)
 	if err != nil {
 		log.Printf("Failed to get user Sentry config: %v", err)
 		// Get default base URL from sentry service config
@@ -276,7 +277,7 @@ func TestSentryConnection(c *gin.Context) {
 		}
 
 		// Get user's Sentry config from database
-		config, err := backendClient.GetUserSentryConfig(userID)
+		config, err := backendClient.GetUserSentryConfig(userID, middleware.GetSessionIDFromContext(c))
 		if err != nil {
 			log.Printf("Failed to get user Sentry config: %v", err)
 			c.JSON(http.StatusBadRequest, gin.H{

--- a/proto/auth.proto
+++ b/proto/auth.proto
@@ -197,6 +197,7 @@ message OAuthProvider {
 // User Groups Messages
 message GetUserGroupsRequest {
   string user_id = 1;
+  string session_id = 2; // Required for authorization
 }
 
 message GetUserGroupsResponse {
@@ -215,6 +216,7 @@ message UserGroup {
 message SyncUserGroupsRequest {
   string user_id = 1;
   string provider = 2;
+  string session_id = 3; // Required for authorization
 }
 
 message SyncUserGroupsResponse {
@@ -226,6 +228,7 @@ message SyncUserGroupsResponse {
 // Sentry Integration Messages
 message GetUserSentryConfigRequest {
   string user_id = 1;
+  string session_id = 2; // Required for authorization
 }
 
 message GetUserSentryConfigResponse {


### PR DESCRIPTION
## Summary

Three `AuthService` RPCs — `GetUserGroups`, `SyncUserGroups`, `GetUserSentryConfig` — acted on a caller-supplied `user_id` without ever reading `req.SessionId`. Anything able to reach the backend gRPC port (published on the host in `docker-compose.yml`, a ClusterIP under the Helm chart) could read any user's OAuth group memberships/permissions and Sentry config, and — once OAuth token persistence is wired up — write another user's groups via `SyncUserGroups`.

## Changes

- `proto/auth.proto`: added `session_id` to `GetUserGroupsRequest`, `SyncUserGroupsRequest`, `GetUserSentryConfigRequest`; regenerated with `scripts/generate_proto.sh` (`make proto` is masked by the `proto/` directory that already exists at repo root, so the raw generator script was used instead).
- `internal/backend/services/services.go`: each of the three RPCs now validates `req.SessionId` via `s.db.GetUserBySession`, then resolves the target user through `resolveTargetUser` (`impersonation.go`) — self-access always succeeds, cross-user access is governed by the existing `NOTIFICATOR_ADMIN_IMPERSONATION_ALLOWED_USERS` allowlist. Matches the pattern already used by `GetUserSentryToken` and the color-preference/hidden-alert RPCs.
- `AuthServiceGorm` now takes a `*config.AdminConfig`, mirroring `AlertServiceGorm`; wired up in `internal/backend/server.go`.
- `internal/webui/client/backend_client.go` + `internal/webui/handlers/oauth_handlers.go` / `sentry_handlers.go`: pass the caller's own session id through to the three RPCs. The WebUI already ran these behind `RequireAuth` using the session user's own id, so the three REST endpoints (`GET /api/v1/oauth/groups`, `POST /api/v1/oauth/sync-groups`, `GET /api/v1/dashboard/sentry-config`) are unaffected.
- New regression tests in `internal/backend/services/auth_impersonation_test.go`, mirroring `impersonation_test.go`: missing session and foreign `user_id` are rejected for all three RPCs, self-access and allowlisted-admin impersonation succeed.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (209 passed, includes 12 new regression tests)
- [x] Verified the proto diff only adds the `session_id` field (no RPC signature changes, `*_grpc.pb.go` untouched)

Closes #147

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>