### PR TITLE
docs(wiki): sync with recent changes

### DIFF
--- a/openwiki/.last-update.json
+++ b/openwiki/.last-update.json
@@ -1,6 +1,6 @@
 {
-  "updatedAt": "2026-07-30T11:59:34.000Z",
+  "updatedAt": "2026-08-01T05:33:10.000Z",
   "command": "update",
-  "gitHead": "d42d5da822f8884921b0ea9852d653bda47a3158",
+  "gitHead": "e06b1c464aa8ac3fa0c3b6ae3bd45cbb8539bfcb",
   "model": "claude-sonnet-5"
 }

--- a/openwiki/backend.md
+++ b/openwiki/backend.md
@@ -30,6 +30,10 @@ The entire auth model is: **every RPC takes a `session_id` string and calls
 
 - **No auth interceptor.** Each handler validates the session by hand. A new RPC that forgets
   the check has *no* auth. This is the single most important thing to know before adding an RPC.
+  `GetUserGroups`, `SyncUserGroups`, and `GetUserSentryConfig` shipped without this check and were
+  retrofitted to require `session_id` + `db.GetUserBySession`, resolving the target user through
+  the same `resolveTargetUser(adminConfig, authenticatedUser, requestedUserID, ...)` helper used
+  for impersonation — grep new RPCs against this list before assuming session-gating is a given.
 - `Login` creates a bcrypt-checked `User` session with a random hex `session_id`, 7-day expiry
   (`internal/backend/services/services.go`). `User` supports both local password and OAuth
   identity (`OAuthProvider`/`OAuthID`, `internal/backend/models/models.go`).
@@ -137,4 +141,7 @@ only** (no cross-replica fan-out). See [architecture](architecture.md#real-time)
 - **Single-replica constraint:** in-memory subscriptions break under horizontal scaling.
 - **Encryption key is mandatory:** the backend refuses to start (non-zero exit before the gRPC
   server accepts connections) unless `NOTIFICATOR_ENCRYPTION_KEY` is set to a valid 64-hex key —
-  see [configuration](configuration.md#sentry).
+  see [configuration](configuration.md#sentry). `docker-compose.yml`'s default is an obviously-fake
+  `badbad...` key (previously a real-looking key, now known to be public via git history);
+  `ValidateEncryptionKey` logs a startup warning if the running key still matches that dev
+  default, since that means Sentry token encryption is backed by a non-secret key.

--- a/openwiki/dashboard.md
+++ b/openwiki/dashboard.md
@@ -180,7 +180,10 @@ comment/audit write sites; a `comments.Kind` column and a `comments.created_at` 
 `AlertDetailsModal` (`components/modal_components.templ:921`), opened by
 `showAlertDetails(fingerprint)` (`dashboard_modal.templ:6`), which `pushState`s the URL to
 `/dashboard/alert/:fingerprint` so deep links work (`router.go:354` re-renders the page and
-`checkAlertFromURL()` reopens the modal). Data comes from `GET /api/v1/dashboard/alert/:fingerprint`
+`checkAlertFromURL()` reopens the modal). A fingerprint unknown to both the live cache and
+`resolved_alerts`, or a fetch failure, now surfaces a `showActionError()` toast instead of just
+a browser-console log — a bare deep link to a purged/expired alert used to fail silently.
+Data comes from `GET /api/v1/dashboard/alert/:fingerprint`
 → `GetAlertDetails` (`dashboard_handlers.go:1231`): the cached alert plus, if the backend is
 connected, its comments and acknowledgments.
 

--- a/openwiki/webui.md
+++ b/openwiki/webui.md
@@ -27,7 +27,10 @@ Middleware order (`router.go:130-134`): `CORSMiddleware` → `LoggingMiddleware`
   fixed for HTTPS-only production.
 - The cookie holds only an opaque `session_id` (+ cached user fields); validity is always
   re-checked against the backend via `ValidateSession` **on every request** — no local TTL
-  cache, so backend load scales 1:1 with UI traffic.
+  cache, so backend load scales 1:1 with UI traffic. `middleware/auth.go` distinguishes a
+  **transient backend-unavailable error** (`client.IsUnavailableError`) from an actually invalid
+  session: the former returns `503`/keeps the cookie intact instead of clearing the session and
+  bouncing the user to the login page, so a brief backend blip no longer logs everyone out.
 - **Classic login/register** (`handlers/handlers.go`) POST form creds to the backend; can be
   disabled via OAuth `DisableClassicAuth`.
 - **OAuth** (`handlers/oauth_handlers.go`): CSRF `state` stored in session, provider auth URL


### PR DESCRIPTION
Automated openwiki refresh covering:
fix(webui): check Success flag in acknowledge and comment RPCs (#133)
feat(webui): editable silence matchers in the silence modal (#139)
fix(webui): silent failure when an alert deep link is unknown to both live cache and resolved_alerts (#142)
fix(security): stop shipping a public encryption key in docker-compose.yml (#143)
feat(factory-tui): show ideator-product, ideator-tui and cleaner desks in the roster
fix(webui): Sentry personal tokens are sent to whatever host an alert annotation points at (#134)
fix(backend): require session validation on GetUserGroups, SyncUserGroups and GetUserSentryConfig (#148)
fix(webui): transient 503s kick authenticated users to the login page (#119)

<!-- doc-agent -->