### PR TITLE
fix(webui): snapshot alert before spawning CaptureAlertFired goroutine

### DIFF
--- a/internal/webui/services/alert_cache.go
+++ b/internal/webui/services/alert_cache.go
@@ -245,10 +245,14 @@ func (ac *AlertCache) refreshAlerts() {
 			alertCopy := *dashAlert
 			newAlertsForSSE = append(newAlertsForSSE, &alertCopy)
 
-			// Capture alert fired event for statistics
+			// Capture alert fired event for statistics. Snapshot the same way as
+			// the resolved path below: dashAlert now lives in ac.alerts and the
+			// next refresh's updateExistingAlert will rewrite its Status and
+			// Annotations under ac.mu while this goroutine reads them unlocked.
+			firedCopy := *dashAlert
 			ac.runBounded(func() {
 				if ac.backendClient != nil && ac.backendClient.IsConnected() {
-					if err := ac.backendClient.CaptureAlertFired(dashAlert); err != nil {
+					if err := ac.backendClient.CaptureAlertFired(&firedCopy); err != nil {
 						log.Printf("Failed to capture alert fired statistics for %s: %v", dashAlert.Fingerprint, err)
 					}
 				}
@@ -288,7 +292,10 @@ func (ac *AlertCache) refreshAlerts() {
 			alert.Status.State = "resolved"
 			alert.EndsAt = alert.ResolvedAt
 
-			// Update alert resolved event for statistics
+			// Update alert resolved event for statistics. Uses the cache-resident
+			// pointer, not a snapshot: fingerprint is deleted from ac.alerts below
+			// within this same locked section, so no later refresh can take the
+			// existing-alert branch and mutate this struct again.
 			ac.runBounded(func() {
 				if ac.backendClient != nil && ac.backendClient.IsConnected() {
 					if err := ac.backendClient.UpdateAlertResolved(alert); err != nil {

--- a/internal/webui/services/alert_cache_test.go
+++ b/internal/webui/services/alert_cache_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"notificator/internal/alertmanager"
 	alertpb "notificator/internal/backend/proto/alert"
 	"notificator/internal/models"
+	"notificator/internal/webui/client"
 	webuimodels "notificator/internal/webui/models"
 )
 
@@ -1443,4 +1445,53 @@ func TestAlertCache_AcknowledgmentDoesNotSurviveResolution(t *testing.T) {
 	if refired.AcknowledgedBy != "" || !refired.AcknowledgedAt.IsZero() || refired.AcknowledgeReason != "" {
 		t.Errorf("acknowledgment fields not cleared: %+v", refired)
 	}
+}
+
+// TestAlertCache_CaptureAlertFiredSnapshot reproduces #161: a refresh that
+// sees a brand-new alert used to hand the CaptureAlertFired goroutine the
+// pointer it had just stored in ac.alerts, rather than a snapshot. The very
+// next refresh cycle mutates that same struct's Status and Annotations under
+// ac.mu, in updateExistingAlert, while the goroutine reads them with no lock
+// held. Run with -race: this fails on the pre-fix code (dashAlert handed
+// straight to CaptureAlertFired) and passes once the goroutine gets its own
+// copy.
+func TestAlertCache_CaptureAlertFiredSnapshot(t *testing.T) {
+	// grpc.NewClient connects lazily, so this never dials: IsConnected() is
+	// true immediately, and CaptureAlertFired reads its alert argument before
+	// it ever touches the network.
+	backendClient := client.NewBackendClient("127.0.0.1:1")
+	if err := backendClient.Connect(); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	cache := NewAlertCache(nil, backendClient, 90, 10*time.Second)
+
+	var firing []alertmanager.AlertWithSource
+	for i := 0; i < 5; i++ {
+		firing = append(firing, alertmanager.AlertWithSource{
+			Alert: models.Alert{
+				Labels:      map[string]string{"alertname": fmt.Sprintf("Race%d", i)},
+				Annotations: map[string]string{"summary": "before"},
+				Status:      models.AlertStatus{State: "firing"},
+				StartsAt:    time.Now(),
+			},
+			Source: "prod",
+		})
+	}
+
+	cache.alertmanagerClient = &fakeAlertFetcher{alerts: firing}
+	cache.refreshAlerts() // inserts the alerts, spawns a CaptureAlertFired goroutine per alert
+
+	silenced := make([]alertmanager.AlertWithSource, len(firing))
+	for i, a := range firing {
+		silenced[i] = a
+		silenced[i].Alert.Annotations = map[string]string{"summary": "after"}
+		silenced[i].Alert.Status = models.AlertStatus{State: "suppressed", SilencedBy: []string{"sil-1"}}
+	}
+	cache.alertmanagerClient = &fakeAlertFetcher{alerts: silenced}
+	cache.refreshAlerts() // same fingerprints: rewrites Status/Annotations on the cached structs
+
+	// Give the CaptureAlertFired goroutines time to run their (unsynchronized,
+	// pre-fix) field reads before the test process exits.
+	time.Sleep(300 * time.Millisecond)
 }


### PR DESCRIPTION
## Summary

`refreshAlerts` spawned the `CaptureAlertFired` statistics goroutine with the pointer it had just stored in `ac.alerts`, not a snapshot. The very next refresh cycle rewrites that same struct's `Status` and `Annotations` under `ac.mu` in `updateExistingAlert`, while the goroutine reads them with no lock held. `Status` is a multi-word struct, so the unsynchronized write/read pair can produce a torn read — best case a wrong `silenced_at_fire` permanently recorded in `alert_statistics`, worst case a crash.

This mirrors the fix already applied to the neighbouring resolved-alert goroutine (`b3d9002`), which just wasn't carried over to this call site.

## Changes

- `internal/webui/services/alert_cache.go`: snapshot `dashAlert` into `firedCopy` under `ac.mu` before spawning the `CaptureAlertFired` goroutine, and pass the copy instead of the cache-resident pointer.
- Checked the `UpdateAlertResolved` goroutine twelve lines down, as the issue asked: it doesn't need the same treatment because its fingerprint is deleted from `ac.alerts` within the same locked section, so no later refresh can reach that struct again. Added a comment recording that reasoning instead of a redundant copy.
- `internal/webui/services/alert_cache_test.go`: new `TestAlertCache_CaptureAlertFiredSnapshot`, which drives a refresh that inserts new alerts immediately followed by a refresh that mutates their `Status`/`Annotations`. Verified it fails under `go test -race` against the pre-fix code (caught the exact write/read pair at `alert_cache.go:419` / `backend_client.go:1836`) and passes after the fix.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./internal/webui/...` (162 tests pass)
- [x] Confirmed the new test fails with `-race` on the pre-fix code and passes after

Closes #161