### PR TITLE
fix(webui): profile page renders fabricated account/session data and its Copy-ID button copies a literal template string

### DIFF
--- a/internal/backend/services/profile_dates_test.go
+++ b/internal/backend/services/profile_dates_test.go
@@ -1,0 +1,42 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	authpb "notificator/internal/backend/proto/auth"
+)
+
+// TestProfileDatesAreReal guards against #177 regressing: ValidateSession and
+// GetProfile must return the account's actual created_at/last_login instead
+// of the webui handler inventing them with time.Now() arithmetic.
+func TestProfileDatesAreReal(t *testing.T) {
+	svc, sessionID := setupAuthServiceWithSession(t)
+	ctx := context.Background()
+
+	validate, err := svc.ValidateSession(ctx, &authpb.ValidateSessionRequest{SessionId: sessionID})
+	if err != nil {
+		t.Fatalf("ValidateSession: %v", err)
+	}
+	if validate.User.CreatedAt == nil {
+		t.Fatal("ValidateSession: CreatedAt is nil, want the account's real creation time")
+	}
+	if validate.User.LastLogin != nil {
+		t.Fatalf("ValidateSession: LastLogin = %v, want nil (never logged in)", validate.User.LastLogin)
+	}
+
+	if err := svc.db.UpdateLastLogin(validate.User.Id); err != nil {
+		t.Fatalf("UpdateLastLogin: %v", err)
+	}
+
+	profile, err := svc.GetProfile(ctx, &authpb.GetProfileRequest{SessionId: sessionID})
+	if err != nil {
+		t.Fatalf("GetProfile: %v", err)
+	}
+	if profile.User.CreatedAt == nil {
+		t.Fatal("GetProfile: CreatedAt is nil, want the account's real creation time")
+	}
+	if profile.User.LastLogin == nil {
+		t.Fatal("GetProfile: LastLogin is nil after UpdateLastLogin, want it populated")
+	}
+}

--- a/internal/backend/services/services.go
+++ b/internal/backend/services/services.go
@@ -243,6 +243,9 @@ func (s *AuthServiceGorm) ValidateSession(ctx context.Context, req *authpb.Valid
 	if user.Timezone != nil {
 		resp.User.Timezone = *user.Timezone
 	}
+	if user.LastLogin != nil {
+		resp.User.LastLogin = timestamppb.New(*user.LastLogin)
+	}
 	return resp, nil
 }
 
@@ -271,6 +274,9 @@ func (s *AuthServiceGorm) GetProfile(ctx context.Context, req *authpb.GetProfile
 	}
 	if user.Timezone != nil {
 		resp.User.Timezone = *user.Timezone
+	}
+	if user.LastLogin != nil {
+		resp.User.LastLogin = timestamppb.New(*user.LastLogin)
 	}
 	return resp, nil
 }

--- a/internal/webui/client/backend_client.go
+++ b/internal/webui/client/backend_client.go
@@ -49,12 +49,14 @@ type AuthResult struct {
 }
 
 type User struct {
-	ID            string  `json:"id"`
-	Username      string  `json:"username"`
-	Email         string  `json:"email"`
-	OAuthProvider *string `json:"oauth_provider,omitempty"`
-	OAuthID       *string `json:"oauth_id,omitempty"`
-	Timezone      *string `json:"timezone,omitempty"`
+	ID            string     `json:"id"`
+	Username      string     `json:"username"`
+	Email         string     `json:"email"`
+	OAuthProvider *string    `json:"oauth_provider,omitempty"`
+	OAuthID       *string    `json:"oauth_id,omitempty"`
+	Timezone      *string    `json:"timezone,omitempty"`
+	CreatedAt     time.Time  `json:"created_at"`
+	LastLogin     *time.Time `json:"last_login,omitempty"`
 }
 
 // IsOAuthUser returns true if the user was created via OAuth
@@ -310,6 +312,13 @@ func (c *BackendClient) ValidateSession(sessionID string) (*User, error) {
 	if resp.User.Timezone != "" {
 		user.Timezone = &resp.User.Timezone
 	}
+	if resp.User.CreatedAt != nil {
+		user.CreatedAt = resp.User.CreatedAt.AsTime()
+	}
+	if resp.User.LastLogin != nil {
+		lastLogin := resp.User.LastLogin.AsTime()
+		user.LastLogin = &lastLogin
+	}
 
 	return user, nil
 }
@@ -368,6 +377,13 @@ func (c *BackendClient) GetProfile(sessionID string) (*User, error) {
 	}
 	if resp.User.Timezone != "" {
 		user.Timezone = &resp.User.Timezone
+	}
+	if resp.User.CreatedAt != nil {
+		user.CreatedAt = resp.User.CreatedAt.AsTime()
+	}
+	if resp.User.LastLogin != nil {
+		lastLogin := resp.User.LastLogin.AsTime()
+		user.LastLogin = &lastLogin
 	}
 
 	return user, nil

--- a/internal/webui/handlers/profile_handlers.go
+++ b/internal/webui/handlers/profile_handlers.go
@@ -42,20 +42,11 @@ func ProfilePage(c *gin.Context) {
 			Email:         user.Email,
 			OAuthProvider: oauthProvider,
 			OAuthID:       user.OAuthID,
-			CreatedAt:     time.Now().AddDate(0, -3, -15),
-			LastLogin:     &[]time.Time{time.Now().Add(-2 * time.Hour)}[0],
-			EmailVerified: user.Email != "",
+			CreatedAt:     user.CreatedAt,
+			LastLogin:     user.LastLogin,
 		},
 		SessionInfo: pages.SessionInfo{
 			SessionID: sessionID,
-			CreatedAt: time.Now().Add(-30 * time.Minute),
-			ExpiresAt: time.Now().Add(7 * 24 * time.Hour),
-		},
-		Stats: pages.UserStats{
-			TotalAlerts:    156,
-			ActiveAlerts:   12,
-			ResolvedAlerts: 144,
-			LastActivity:   &[]time.Time{time.Now().Add(-5 * time.Minute)}[0],
 		},
 	}
 

--- a/internal/webui/templates/pages/Profile.templ
+++ b/internal/webui/templates/pages/Profile.templ
@@ -7,9 +7,8 @@ import (
 )
 
 type ProfileData struct {
-	User         ProfileUser
-	SessionInfo  SessionInfo
-	Stats        UserStats
+	User        ProfileUser
+	SessionInfo SessionInfo
 }
 
 type ProfileUser struct {
@@ -20,20 +19,10 @@ type ProfileUser struct {
 	OAuthID       *string
 	CreatedAt     time.Time
 	LastLogin     *time.Time
-	EmailVerified bool
 }
 
 type SessionInfo struct {
-	SessionID  string
-	CreatedAt  time.Time
-	ExpiresAt  time.Time
-}
-
-type UserStats struct {
-	TotalAlerts      int
-	ActiveAlerts     int
-	ResolvedAlerts   int
-	LastActivity     *time.Time
+	SessionID string
 }
 
 templ Profile(data ProfileData) {
@@ -41,7 +30,7 @@ templ Profile(data ProfileData) {
 }
 
 templ ProfileContent(data ProfileData) {
-	<div class="min-h-screen bg-gray-50 dark:bg-dark-bg-primary py-8" x-data="profilePage()">
+	<div class="min-h-screen bg-gray-50 dark:bg-dark-bg-primary py-8" x-data="profilePage()" data-user-id={ data.User.ID }>
 		<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
 			<!-- Header -->
 			<div class="mb-8">
@@ -105,29 +94,23 @@ templ ProfileContent(data ProfileData) {
 												Classic Auth
 											</div>
 										}
-										
-										if data.User.EmailVerified {
-											<div class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400">
-												<svg class="mr-1.5 h-3 w-3" fill="currentColor" viewBox="0 0 20 20">
-													<path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
-												</svg>
-												Verified
-											</div>
-										}
 									</div>
 								</div>
 
 								<!-- Copy ID Button -->
 								<div class="flex-shrink-0">
-									<button 
-										@click="copyUserId()" 
+									<button
+										@click="copyUserId()"
 										class="inline-flex items-center px-3 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm leading-4 font-medium rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-dark-bg-tertiary hover:bg-gray-50 dark:hover:bg-dark-bg-secondary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors"
 										title="Copy User ID"
 									>
-										<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+										<svg x-show="!idCopied" class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
 										</svg>
-										<span class="ml-2">ID</span>
+										<svg x-show="idCopied" style="display: none;" class="h-4 w-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+										</svg>
+										<span class="ml-2" x-text="idCopied ? 'Copied' : 'ID'"></span>
 									</button>
 								</div>
 							</div>
@@ -171,24 +154,6 @@ templ ProfileContent(data ProfileData) {
 								<div>
 									<dt class="text-sm font-medium text-gray-500 dark:text-gray-400">Session ID</dt>
 									<dd class="mt-1 text-xs text-gray-900 dark:text-white font-mono truncate">{ data.SessionInfo.SessionID }</dd>
-								</div>
-								<div>
-									<dt class="text-sm font-medium text-gray-500 dark:text-gray-400">Session Started</dt>
-									<dd class="mt-1 text-sm text-gray-900 dark:text-white">{ templates.FormatDate(data.SessionInfo.CreatedAt) }</dd>
-								</div>
-								<div>
-									<dt class="text-sm font-medium text-gray-500 dark:text-gray-400">Expires</dt>
-									<dd class="mt-1 text-sm text-gray-900 dark:text-white">{ templates.FormatDate(data.SessionInfo.ExpiresAt) }</dd>
-								</div>
-								
-								<!-- Session Duration -->
-								<div class="pt-3 border-t border-gray-200 dark:border-gray-700">
-									<div class="flex items-center justify-between">
-										<span class="text-sm text-gray-500 dark:text-gray-400">Duration</span>
-										<span class="text-sm font-medium text-gray-900 dark:text-white">
-											{ templates.FormatDuration(time.Since(data.SessionInfo.CreatedAt)) }
-										</span>
-									</div>
 								</div>
 							</div>
 						</div>
@@ -238,14 +203,18 @@ templ ProfileContent(data ProfileData) {
 	<script>
 		function profilePage() {
 			return {
-				showToast: false,
-				userId: '{ data.User.ID }',
-				
+				idCopied: false,
+				userId: '',
+
+				init() {
+					this.userId = this.$el.dataset.userId;
+				},
+
 				copyUserId() {
 					navigator.clipboard.writeText(this.userId).then(() => {
-						this.showToast = true;
+						this.idCopied = true;
 						setTimeout(() => {
-							this.showToast = false;
+							this.idCopied = false;
 						}, 2000);
 					}).catch(err => {
 						console.error('Failed to copy:', err);
@@ -256,13 +225,13 @@ templ ProfileContent(data ProfileData) {
 						input.select();
 						document.execCommand('copy');
 						document.body.removeChild(input);
-						this.showToast = true;
+						this.idCopied = true;
 						setTimeout(() => {
-							this.showToast = false;
+							this.idCopied = false;
 						}, 2000);
 					});
 				},
-				
+
 				showChangePassword() {
 					// TODO: Implement change password modal
 					alert('Change password functionality coming soon!');

--- a/internal/webui/templates/pages/Profile_templ.go
+++ b/internal/webui/templates/pages/Profile_templ.go
@@ -17,7 +17,6 @@ import (
 type ProfileData struct {
 	User        ProfileUser
 	SessionInfo SessionInfo
-	Stats       UserStats
 }
 
 type ProfileUser struct {
@@ -28,20 +27,10 @@ type ProfileUser struct {
 	OAuthID       *string
 	CreatedAt     time.Time
 	LastLogin     *time.Time
-	EmailVerified bool
 }
 
 type SessionInfo struct {
 	SessionID string
-	CreatedAt time.Time
-	ExpiresAt time.Time
-}
-
-type UserStats struct {
-	TotalAlerts    int
-	ActiveAlerts   int
-	ResolvedAlerts int
-	LastActivity   *time.Time
 }
 
 func Profile(data ProfileData) templ.Component {
@@ -94,51 +83,64 @@ func ProfileContent(data ProfileData) templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"min-h-screen bg-gray-50 dark:bg-dark-bg-primary py-8\" x-data=\"profilePage()\"><div class=\"max-w-4xl mx-auto px-4 sm:px-6 lg:px-8\"><!-- Header --><div class=\"mb-8\"><nav class=\"flex\" aria-label=\"Breadcrumb\"><ol class=\"flex items-center space-x-4\"><li><a href=\"/dashboard\" class=\"text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400\"><svg class=\"flex-shrink-0 h-5 w-5\" viewBox=\"0 0 20 20\" fill=\"currentColor\"><path d=\"M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z\"></path></svg> <span class=\"sr-only\">Dashboard</span></a></li><li><div class=\"flex items-center\"><svg class=\"flex-shrink-0 h-5 w-5 text-gray-400\" viewBox=\"0 0 20 20\" fill=\"currentColor\"><path fill-rule=\"evenodd\" d=\"M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z\" clip-rule=\"evenodd\"></path></svg> <span class=\"ml-4 text-sm font-medium text-gray-500 dark:text-gray-400\">Profile</span></div></li></ol></nav><h1 class=\"mt-4 text-3xl font-bold text-gray-900 dark:text-white\">My Profile</h1></div><!-- Profile Cards Grid --><div class=\"grid grid-cols-1 gap-6 lg:grid-cols-3\"><!-- User Info Card (spans 2 columns on lg) --><div class=\"lg:col-span-2\"><div class=\"bg-white dark:bg-dark-bg-secondary rounded-lg shadow-sm border border-gray-200 dark:border-dark-border-subtle overflow-hidden\"><div class=\"px-6 py-5\"><div class=\"flex items-start space-x-5\"><!-- Avatar --><div class=\"flex-shrink-0\"><div class=\"h-20 w-20 rounded-full bg-gradient-to-r from-blue-500 to-purple-600 flex items-center justify-center\"><span class=\"text-2xl font-bold text-white\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"min-h-screen bg-gray-50 dark:bg-dark-bg-primary py-8\" x-data=\"profilePage()\" data-user-id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var3 string
-		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(templates.GetInitials(data.User.Username))
+		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(data.User.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/webui/templates/pages/Profile.templ`, Line: 81, Col: 97}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/webui/templates/pages/Profile.templ`, Line: 33, Col: 117}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</span></div></div><!-- User Details --><div class=\"flex-1 min-w-0\"><h2 class=\"text-2xl font-bold text-gray-900 dark:text-white truncate\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\"><div class=\"max-w-4xl mx-auto px-4 sm:px-6 lg:px-8\"><!-- Header --><div class=\"mb-8\"><nav class=\"flex\" aria-label=\"Breadcrumb\"><ol class=\"flex items-center space-x-4\"><li><a href=\"/dashboard\" class=\"text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400\"><svg class=\"flex-shrink-0 h-5 w-5\" viewBox=\"0 0 20 20\" fill=\"currentColor\"><path d=\"M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z\"></path></svg> <span class=\"sr-only\">Dashboard</span></a></li><li><div class=\"flex items-center\"><svg class=\"flex-shrink-0 h-5 w-5 text-gray-400\" viewBox=\"0 0 20 20\" fill=\"currentColor\"><path fill-rule=\"evenodd\" d=\"M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z\" clip-rule=\"evenodd\"></path></svg> <span class=\"ml-4 text-sm font-medium text-gray-500 dark:text-gray-400\">Profile</span></div></li></ol></nav><h1 class=\"mt-4 text-3xl font-bold text-gray-900 dark:text-white\">My Profile</h1></div><!-- Profile Cards Grid --><div class=\"grid grid-cols-1 gap-6 lg:grid-cols-3\"><!-- User Info Card (spans 2 columns on lg) --><div class=\"lg:col-span-2\"><div class=\"bg-white dark:bg-dark-bg-secondary rounded-lg shadow-sm border border-gray-200 dark:border-dark-border-subtle overflow-hidden\"><div class=\"px-6 py-5\"><div class=\"flex items-start space-x-5\"><!-- Avatar --><div class=\"flex-shrink-0\"><div class=\"h-20 w-20 rounded-full bg-gradient-to-r from-blue-500 to-purple-600 flex items-center justify-center\"><span class=\"text-2xl font-bold text-white\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var4 string
-		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(data.User.Username)
+		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(templates.GetInitials(data.User.Username))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/webui/templates/pages/Profile.templ`, Line: 88, Col: 30}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/webui/templates/pages/Profile.templ`, Line: 70, Col: 97}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</h2><p class=\"mt-1 text-sm text-gray-500 dark:text-gray-400\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</span></div></div><!-- User Details --><div class=\"flex-1 min-w-0\"><h2 class=\"text-2xl font-bold text-gray-900 dark:text-white truncate\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var5 string
-		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(data.User.Email)
+		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(data.User.Username)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/webui/templates/pages/Profile.templ`, Line: 91, Col: 27}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/webui/templates/pages/Profile.templ`, Line: 77, Col: 30}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</p><!-- Auth Method Badge --><div class=\"mt-3 flex items-center space-x-2\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</h2><p class=\"mt-1 text-sm text-gray-500 dark:text-gray-400\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var6 string
+		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(data.User.Email)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/webui/templates/pages/Profile.templ`, Line: 80, Col: 27}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</p><!-- Auth Method Badge --><div class=\"mt-3 flex items-center space-x-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if data.User.OAuthProvider != nil {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div class=\"inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div class=\"inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -146,32 +148,26 @@ func ProfileContent(data ProfileData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div class=\"inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300\"><svg class=\"mr-1.5 h-3 w-3\" fill=\"currentColor\" viewBox=\"0 0 20 20\"><path fill-rule=\"evenodd\" d=\"M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z\" clip-rule=\"evenodd\"></path></svg> Classic Auth</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<div class=\"inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300\"><svg class=\"mr-1.5 h-3 w-3\" fill=\"currentColor\" viewBox=\"0 0 20 20\"><path fill-rule=\"evenodd\" d=\"M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z\" clip-rule=\"evenodd\"></path></svg> Classic Auth</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		if data.User.EmailVerified {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<div class=\"inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400\"><svg class=\"mr-1.5 h-3 w-3\" fill=\"currentColor\" viewBox=\"0 0 20 20\"><path fill-rule=\"evenodd\" d=\"M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z\" clip-rule=\"evenodd\"></path></svg> Verified</div>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div></div><!-- Copy ID Button --><div class=\"flex-shrink-0\"><button @click=\"copyUserId()\" class=\"inline-flex items-center px-3 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm leading-4 font-medium rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-dark-bg-tertiary hover:bg-gray-50 dark:hover:bg-dark-bg-secondary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors\" title=\"Copy User ID\"><svg class=\"h-4 w-4\" fill=\"none\" stroke=\"currentColor\" viewBox=\"0 0 24 24\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z\"></path></svg> <span class=\"ml-2\">ID</span></button></div></div><!-- Account Details Grid --><div class=\"mt-6 grid grid-cols-1 sm:grid-cols-2 gap-4\"><div class=\"overflow-hidden\"><dt class=\"text-sm font-medium text-gray-500 dark:text-gray-400\">User ID</dt><dd class=\"mt-1 text-sm text-gray-900 dark:text-white font-mono truncate\" title=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div></div><!-- Copy ID Button --><div class=\"flex-shrink-0\"><button @click=\"copyUserId()\" class=\"inline-flex items-center px-3 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm leading-4 font-medium rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-dark-bg-tertiary hover:bg-gray-50 dark:hover:bg-dark-bg-secondary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors\" title=\"Copy User ID\"><svg x-show=\"!idCopied\" class=\"h-4 w-4\" fill=\"none\" stroke=\"currentColor\" viewBox=\"0 0 24 24\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z\"></path></svg> <svg x-show=\"idCopied\" style=\"display: none;\" class=\"h-4 w-4 text-green-500\" fill=\"none\" stroke=\"currentColor\" viewBox=\"0 0 24 24\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M5 13l4 4L19 7\"></path></svg> <span class=\"ml-2\" x-text=\"idCopied ? 'Copied' : 'ID'\"></span></button></div></div><!-- Account Details Grid --><div class=\"mt-6 grid grid-cols-1 sm:grid-cols-2 gap-4\"><div class=\"overflow-hidden\"><dt class=\"text-sm font-medium text-gray-500 dark:text-gray-400\">User ID</dt><dd class=\"mt-1 text-sm text-gray-900 dark:text-white font-mono truncate\" title=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var6 string
-		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(data.User.ID)
+		var templ_7745c5c3_Var7 string
+		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(data.User.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/webui/templates/pages/Profile.templ`, Line: 139, Col: 103}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/webui/templates/pages/Profile.templ`, Line: 122, Col: 103}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -179,12 +175,12 @@ func ProfileContent(data ProfileData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var7 string
-		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(data.User.ID)
+		var templ_7745c5c3_Var8 string
+		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(data.User.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/webui/templates/pages/Profile.templ`, Line: 139, Col: 120}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/webui/templates/pages/Profile.templ`, Line: 122, Col: 120}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -192,12 +188,12 @@ func ProfileContent(data ProfileData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var8 string
-		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(templates.FormatDate(data.User.CreatedAt))
+		var templ_7745c5c3_Var9 string
+		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(templates.FormatDate(data.User.CreatedAt))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/webui/templates/pages/Profile.templ`, Line: 143, Col: 107}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/webui/templates/pages/Profile.templ`, Line: 126, Col: 107}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -210,12 +206,12 @@ func ProfileContent(data ProfileData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var9 string
-			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(templates.FormatDate(*data.User.LastLogin))
+			var templ_7745c5c3_Var10 string
+			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(templates.FormatDate(*data.User.LastLogin))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/webui/templates/pages/Profile.templ`, Line: 148, Col: 109}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/webui/templates/pages/Profile.templ`, Line: 131, Col: 109}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -229,12 +225,12 @@ func ProfileContent(data ProfileData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var10 string
-			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(*data.User.OAuthID)
+			var templ_7745c5c3_Var11 string
+			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(*data.User.OAuthID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/webui/templates/pages/Profile.templ`, Line: 154, Col: 95}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/webui/templates/pages/Profile.templ`, Line: 137, Col: 95}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -247,65 +243,26 @@ func ProfileContent(data ProfileData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var11 string
-		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(data.SessionInfo.SessionID)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/webui/templates/pages/Profile.templ`, Line: 173, Col: 111}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</dd></div><div><dt class=\"text-sm font-medium text-gray-500 dark:text-gray-400\">Session Started</dt><dd class=\"mt-1 text-sm text-gray-900 dark:text-white\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
 		var templ_7745c5c3_Var12 string
-		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(templates.FormatDate(data.SessionInfo.CreatedAt))
+		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(data.SessionInfo.SessionID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/webui/templates/pages/Profile.templ`, Line: 177, Col: 114}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/webui/templates/pages/Profile.templ`, Line: 156, Col: 111}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</dd></div><div><dt class=\"text-sm font-medium text-gray-500 dark:text-gray-400\">Expires</dt><dd class=\"mt-1 text-sm text-gray-900 dark:text-white\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var13 string
-		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(templates.FormatDate(data.SessionInfo.ExpiresAt))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/webui/templates/pages/Profile.templ`, Line: 181, Col: 114}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</dd></div><!-- Session Duration --><div class=\"pt-3 border-t border-gray-200 dark:border-gray-700\"><div class=\"flex items-center justify-between\"><span class=\"text-sm text-gray-500 dark:text-gray-400\">Duration</span> <span class=\"text-sm font-medium text-gray-900 dark:text-white\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var14 string
-		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(templates.FormatDuration(time.Since(data.SessionInfo.CreatedAt)))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/webui/templates/pages/Profile.templ`, Line: 189, Col: 77}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</span></div></div></div></div></div></div><!-- Quick Actions --><div class=\"lg:col-span-3\"><div class=\"bg-white dark:bg-dark-bg-secondary rounded-lg shadow-sm border border-gray-200 dark:border-dark-border-subtle p-6\"><h3 class=\"text-lg font-medium text-gray-900 dark:text-white mb-4\">Quick Actions</h3><div class=\"grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4\"><a href=\"/dashboard\" class=\"inline-flex items-center justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-dark-bg-tertiary hover:bg-gray-50 dark:hover:bg-dark-bg-secondary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors\"><svg class=\"mr-2 h-4 w-4\" fill=\"none\" stroke=\"currentColor\" viewBox=\"0 0 24 24\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6\"></path></svg> Back to Dashboard</a> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</dd></div></div></div></div></div><!-- Quick Actions --><div class=\"lg:col-span-3\"><div class=\"bg-white dark:bg-dark-bg-secondary rounded-lg shadow-sm border border-gray-200 dark:border-dark-border-subtle p-6\"><h3 class=\"text-lg font-medium text-gray-900 dark:text-white mb-4\">Quick Actions</h3><div class=\"grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4\"><a href=\"/dashboard\" class=\"inline-flex items-center justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-dark-bg-tertiary hover:bg-gray-50 dark:hover:bg-dark-bg-secondary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors\"><svg class=\"mr-2 h-4 w-4\" fill=\"none\" stroke=\"currentColor\" viewBox=\"0 0 24 24\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6\"></path></svg> Back to Dashboard</a> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if data.User.OAuthProvider == nil {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<button @click=\"showChangePassword\" class=\"inline-flex items-center justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-dark-bg-tertiary hover:bg-gray-50 dark:hover:bg-dark-bg-secondary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors\"><svg class=\"mr-2 h-4 w-4\" fill=\"none\" stroke=\"currentColor\" viewBox=\"0 0 24 24\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z\"></path></svg> Change Password</button> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<button @click=\"showChangePassword\" class=\"inline-flex items-center justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-dark-bg-tertiary hover:bg-gray-50 dark:hover:bg-dark-bg-secondary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors\"><svg class=\"mr-2 h-4 w-4\" fill=\"none\" stroke=\"currentColor\" viewBox=\"0 0 24 24\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z\"></path></svg> Change Password</button> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<button hx-post=\"/api/v1/auth/logout\" hx-trigger=\"click\" hx-on::after-request=\"handleLogoutResponse(event)\" class=\"inline-flex items-center justify-center px-4 py-2 border border-red-300 dark:border-red-800 shadow-sm text-sm font-medium rounded-md text-red-700 dark:text-red-400 bg-white dark:bg-dark-bg-tertiary hover:bg-red-50 dark:hover:bg-red-900/20 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors\"><svg class=\"mr-2 h-4 w-4\" fill=\"none\" stroke=\"currentColor\" viewBox=\"0 0 24 24\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1\"></path></svg> Sign Out</button></div></div></div></div></div></div><script>\n\t\tfunction profilePage() {\n\t\t\treturn {\n\t\t\t\tshowToast: false,\n\t\t\t\tuserId: '{ data.User.ID }',\n\t\t\t\t\n\t\t\t\tcopyUserId() {\n\t\t\t\t\tnavigator.clipboard.writeText(this.userId).then(() => {\n\t\t\t\t\t\tthis.showToast = true;\n\t\t\t\t\t\tsetTimeout(() => {\n\t\t\t\t\t\t\tthis.showToast = false;\n\t\t\t\t\t\t}, 2000);\n\t\t\t\t\t}).catch(err => {\n\t\t\t\t\t\tconsole.error('Failed to copy:', err);\n\t\t\t\t\t\t// Fallback for older browsers\n\t\t\t\t\t\tconst input = document.createElement('input');\n\t\t\t\t\t\tinput.value = this.userId;\n\t\t\t\t\t\tdocument.body.appendChild(input);\n\t\t\t\t\t\tinput.select();\n\t\t\t\t\t\tdocument.execCommand('copy');\n\t\t\t\t\t\tdocument.body.removeChild(input);\n\t\t\t\t\t\tthis.showToast = true;\n\t\t\t\t\t\tsetTimeout(() => {\n\t\t\t\t\t\t\tthis.showToast = false;\n\t\t\t\t\t\t}, 2000);\n\t\t\t\t\t});\n\t\t\t\t},\n\t\t\t\t\n\t\t\t\tshowChangePassword() {\n\t\t\t\t\t// TODO: Implement change password modal\n\t\t\t\t\talert('Change password functionality coming soon!');\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t\t\n\t\tfunction handleLogoutResponse(event) {\n\t\t\tif (event.detail.successful) {\n\t\t\t\twindow.location.href = '/';\n\t\t\t}\n\t\t}\n\t</script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<button hx-post=\"/api/v1/auth/logout\" hx-trigger=\"click\" hx-on::after-request=\"handleLogoutResponse(event)\" class=\"inline-flex items-center justify-center px-4 py-2 border border-red-300 dark:border-red-800 shadow-sm text-sm font-medium rounded-md text-red-700 dark:text-red-400 bg-white dark:bg-dark-bg-tertiary hover:bg-red-50 dark:hover:bg-red-900/20 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors\"><svg class=\"mr-2 h-4 w-4\" fill=\"none\" stroke=\"currentColor\" viewBox=\"0 0 24 24\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1\"></path></svg> Sign Out</button></div></div></div></div></div></div><script>\n\t\tfunction profilePage() {\n\t\t\treturn {\n\t\t\t\tidCopied: false,\n\t\t\t\tuserId: '',\n\n\t\t\t\tinit() {\n\t\t\t\t\tthis.userId = this.$el.dataset.userId;\n\t\t\t\t},\n\n\t\t\t\tcopyUserId() {\n\t\t\t\t\tnavigator.clipboard.writeText(this.userId).then(() => {\n\t\t\t\t\t\tthis.idCopied = true;\n\t\t\t\t\t\tsetTimeout(() => {\n\t\t\t\t\t\t\tthis.idCopied = false;\n\t\t\t\t\t\t}, 2000);\n\t\t\t\t\t}).catch(err => {\n\t\t\t\t\t\tconsole.error('Failed to copy:', err);\n\t\t\t\t\t\t// Fallback for older browsers\n\t\t\t\t\t\tconst input = document.createElement('input');\n\t\t\t\t\t\tinput.value = this.userId;\n\t\t\t\t\t\tdocument.body.appendChild(input);\n\t\t\t\t\t\tinput.select();\n\t\t\t\t\t\tdocument.execCommand('copy');\n\t\t\t\t\t\tdocument.body.removeChild(input);\n\t\t\t\t\t\tthis.idCopied = true;\n\t\t\t\t\t\tsetTimeout(() => {\n\t\t\t\t\t\t\tthis.idCopied = false;\n\t\t\t\t\t\t}, 2000);\n\t\t\t\t\t});\n\t\t\t\t},\n\n\t\t\t\tshowChangePassword() {\n\t\t\t\t\t// TODO: Implement change password modal\n\t\t\t\t\talert('Change password functionality coming soon!');\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t\t\n\t\tfunction handleLogoutResponse(event) {\n\t\t\tif (event.detail.successful) {\n\t\t\t\twindow.location.href = '/';\n\t\t\t}\n\t\t}\n\t</script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -329,51 +286,51 @@ func OAuthProviderBadge(provider string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var15 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var15 == nil {
-			templ_7745c5c3_Var15 = templ.NopComponent
+		templ_7745c5c3_Var13 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var13 == nil {
+			templ_7745c5c3_Var13 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<div class=\"flex items-center\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<div class=\"flex items-center\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		switch provider {
 		case "github":
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<svg class=\"mr-1.5 h-3 w-3\" fill=\"currentColor\" viewBox=\"0 0 20 20\"><path fill-rule=\"evenodd\" d=\"M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z\" clip-rule=\"evenodd\"></path></svg> <span>GitHub</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<svg class=\"mr-1.5 h-3 w-3\" fill=\"currentColor\" viewBox=\"0 0 20 20\"><path fill-rule=\"evenodd\" d=\"M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z\" clip-rule=\"evenodd\"></path></svg> <span>GitHub</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		case "google":
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<svg class=\"mr-1.5 h-3 w-3\" viewBox=\"0 0 24 24\"><path fill=\"#4285F4\" d=\"M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z\"></path> <path fill=\"#34A853\" d=\"M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z\"></path> <path fill=\"#FBBC05\" d=\"M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z\"></path> <path fill=\"#EA4335\" d=\"M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z\"></path></svg> <span>Google</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<svg class=\"mr-1.5 h-3 w-3\" viewBox=\"0 0 24 24\"><path fill=\"#4285F4\" d=\"M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z\"></path> <path fill=\"#34A853\" d=\"M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z\"></path> <path fill=\"#FBBC05\" d=\"M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z\"></path> <path fill=\"#EA4335\" d=\"M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z\"></path></svg> <span>Google</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		case "microsoft":
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<svg class=\"mr-1.5 h-3 w-3\" viewBox=\"0 0 24 24\"><path fill=\"#f25022\" d=\"M1 1h10v10H1z\"></path> <path fill=\"#00a4ef\" d=\"M13 1h10v10H13z\"></path> <path fill=\"#7fba00\" d=\"M1 13h10v10H1z\"></path> <path fill=\"#ffb900\" d=\"M13 13h10v10H13z\"></path></svg> <span>Microsoft</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<svg class=\"mr-1.5 h-3 w-3\" viewBox=\"0 0 24 24\"><path fill=\"#f25022\" d=\"M1 1h10v10H1z\"></path> <path fill=\"#00a4ef\" d=\"M13 1h10v10H13z\"></path> <path fill=\"#7fba00\" d=\"M1 13h10v10H1z\"></path> <path fill=\"#ffb900\" d=\"M13 13h10v10H13z\"></path></svg> <span>Microsoft</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		default:
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var16 string
-			templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(provider)
+			var templ_7745c5c3_Var14 string
+			templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(provider)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/webui/templates/pages/Profile.templ`, Line: 306, Col: 20}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/webui/templates/pages/Profile.templ`, Line: 275, Col: 20}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/webui/templates/utils.go
+++ b/internal/webui/templates/utils.go
@@ -1,7 +1,6 @@
 package templates
 
 import (
-	"fmt"
 	"strings"
 	"time"
 )
@@ -19,14 +18,4 @@ func GetInitials(username string) string {
 
 func FormatDate(t time.Time) string {
 	return t.Format("Jan 2, 2006 at 3:04 PM")
-}
-
-func FormatDuration(d time.Duration) string {
-	hours := int(d.Hours())
-	minutes := int(d.Minutes()) % 60
-
-	if hours > 0 {
-		return fmt.Sprintf("%dh %dm", hours, minutes)
-	}
-	return fmt.Sprintf("%dm", minutes)
 }


### PR DESCRIPTION
## Summary

The `/profile` page hardcoded every date it rendered (`time.Now()` arithmetic in `profile_handlers.go`), showed an `EmailVerified` badge that only checked for a non-empty email string, carried a dead hardcoded `UserStats` block, and shipped a Copy-ID button that copied the literal text `{ data.User.ID }` because templ doesn't interpolate inside `<script>` blocks.

- `ValidateSession`/`GetProfile` (backend `AuthServiceGorm`) now also return `LastLogin` on the proto `User` (they already returned `CreatedAt`), matching the pattern already used in `SearchUsers`/`ListUsers`. No proto changes needed — `created_at`/`last_login` were already on the wire format, just dropped by the handlers.
- webui `client.User` now carries `CreatedAt`/`LastLogin`; `profile_handlers.go` renders those directly instead of inventing "3.5 months ago" / "2 hours ago".
- Removed the `EmailVerified` badge — there's no verification flow behind it, so a fabricated flag isn't a fair substitute.
- Removed the hardcoded `UserStats` block (`156`/`12`/`144`), which was already unrendered — dead trap for whoever wires the template to it next.
- The session card now shows only the `Session ID`, which is real. "Session Started" / "Expires" / "Duration" were sourced from constants (30 min ago, +7 days) with no backend record backing them, so they're dropped rather than invented — there's no RPC currently exposing the actual session row's timestamps.
- Copy-ID button: the user ID now travels via a `data-user-id` attribute (read in Alpine's `init()`), not a `<script>` interpolation that templ silently skips. The button swaps to a checkmark + "Copied" on success, mirroring the alert modal's copy-link button (`modal_components.templ`).

Closes #177

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/backend/services/... ./internal/webui/...` (225 passed)
- [x] Added `TestProfileDatesAreReal` covering `ValidateSession`/`GetProfile` returning real `CreatedAt`/`LastLogin`
- [x] `make webui-templates` regenerated `Profile_templ.go` from the edited `.templ`

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>