### PR TITLE
fix(webui): graceful shutdown on SIGTERM/SIGINT

### DIFF
--- a/cmd/webui.go
+++ b/cmd/webui.go
@@ -4,8 +4,14 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -51,11 +57,34 @@ func runWebUI(cmd *cobra.Command, args []string) {
 	fmt.Printf("   Listen: %s\n", listenAddr)
 	fmt.Printf("   Backend: %s\n", backendAddr)
 
-	router := webui.SetupRouter(backendAddr)
+	router, alertCache := webui.SetupRouter(backendAddr)
 
 	fmt.Printf("Visit http://localhost%s to view the WebUI\n", listenAddr)
 
-	if err := router.Run(listenAddr); err != nil {
-		log.Fatal("Failed to start WebUI server:", err)
+	srv := &http.Server{
+		Addr:    listenAddr,
+		Handler: router,
 	}
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatal("Failed to start WebUI server:", err)
+		}
+	}()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	<-ctx.Done()
+
+	fmt.Println("🛑 Shutting down WebUI server...")
+
+	alertCache.Stop()
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		log.Printf("WebUI server shutdown error: %v", err)
+	}
+
+	fmt.Println("✅ WebUI server shut down gracefully")
 }

--- a/internal/webui/router.go
+++ b/internal/webui/router.go
@@ -19,7 +19,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func SetupRouter(backendAddress string) *gin.Engine {
+func SetupRouter(backendAddress string) (*gin.Engine, *services.AlertCache) {
 	r := gin.New()
 
 	// Load configuration with Viper to support environment variables
@@ -384,7 +384,7 @@ func SetupRouter(backendAddress string) *gin.Engine {
 		protectedPages.GET("/activity", handlers.ActivityPage)
 	}
 
-	return r
+	return r, alertCache
 }
 
 // generateRandomSecret generates a cryptographically secure random secret


### PR DESCRIPTION
## Summary
- `runWebUI` (`cmd/webui.go`) previously ended with a bare `router.Run(listenAddr)`, so SIGTERM/SIGINT killed the process immediately, severing in-flight HTTP requests (including SSE dashboard streams) and potentially killing the alert cache poller mid backend-write.
- Wraps the gin engine in an `http.Server` started via `ListenAndServe` in a goroutine.
- Listens for `os.Interrupt`/`syscall.SIGTERM` via `signal.NotifyContext`; on signal, stops the alert cache refresh loop (`alertCache.Stop()`) first, then calls `srv.Shutdown(ctx)` with a 10s drain timeout — mirroring the existing `setupGracefulShutdown` pattern already used by the backend (`internal/backend/server.go:223-258`).
- `SetupRouter` now returns the `*services.AlertCache` alongside the `*gin.Engine` so `runWebUI` can stop it during shutdown.

## Test plan
- [x] `go build ./...` and `go build -tags webui ./...`
- [x] `go vet -tags webui ./...`
- [x] `go test -tags webui ./cmd/... ./internal/webui/...` (210 passed)
- [ ] Manual: `docker-compose restart webui` with an open dashboard no longer shows connection-reset errors beyond the expected SSE reconnect

Closes #184

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>