### PR TITLE
fix(backend): remove crash-prone StreamResolvedAlertUpdates subscription machinery

### DIFF
--- a/internal/backend/services/services.go
+++ b/internal/backend/services/services.go
@@ -1304,14 +1304,6 @@ func (s *AlertServiceGorm) CreateResolvedAlert(ctx context.Context, req *alertpb
 		UpdatedAt:       timestamppb.New(resolvedAlert.UpdatedAt),
 	}
 
-	// Broadcast resolved alert update to subscribers
-	go s.broadcastResolvedAlertUpdate(req.Fingerprint, &alertpb.ResolvedAlertUpdate{
-		Fingerprint:   req.Fingerprint,
-		UpdateType:    alertpb.ResolvedAlertUpdateType_RESOLVED_ALERT_CREATED,
-		ResolvedAlert: pbResolvedAlert,
-		Timestamp:     timestamppb.Now(),
-	})
-
 	return &alertpb.CreateResolvedAlertResponse{
 		Success:       true,
 		ResolvedAlert: pbResolvedAlert,
@@ -1457,88 +1449,13 @@ func (s *AlertServiceGorm) GetResolvedAlert(ctx context.Context, req *alertpb.Ge
 	}, nil
 }
 
-// StreamResolvedAlertUpdates implements the StreamResolvedAlertUpdates RPC method
+// StreamResolvedAlertUpdates implements the StreamResolvedAlertUpdates RPC method.
+// Unimplemented: no consumer in the codebase subscribes to this stream, and the
+// former per-subscriber-goroutine broadcast + double-close-on-dead-stream design
+// could crash the whole backend (see #183). Re-add only with a single writer
+// goroutine per subscription and a stream.Context().Done() watch.
 func (s *AlertServiceGorm) StreamResolvedAlertUpdates(req *alertpb.StreamResolvedAlertUpdatesRequest, stream grpc.ServerStreamingServer[alertpb.ResolvedAlertUpdate]) error {
-	if req.SessionId == "" {
-		return fmt.Errorf("session ID is required")
-	}
-
-	// Validate session
-	_, err := s.db.GetUserBySession(req.SessionId)
-	if err != nil {
-		return fmt.Errorf("invalid session")
-	}
-
-	// Create subscription for resolved alert updates
-	sub := &ResolvedAlertSubscription{
-		SessionID: req.SessionId,
-		Stream:    stream,
-		Done:      make(chan bool),
-	}
-
-	// Add subscription
-	s.addResolvedAlertSubscription(sub)
-	defer s.removeResolvedAlertSubscription(sub)
-
-	// Wait for stream to close
-	<-sub.Done
-
-	return nil
-}
-
-// Helper methods for resolved alert subscriptions
-type ResolvedAlertSubscription struct {
-	SessionID string
-	Stream    grpc.ServerStreamingServer[alertpb.ResolvedAlertUpdate]
-	Done      chan bool
-}
-
-// Add resolved alert subscription tracking
-var (
-	resolvedAlertSubscriptions      = make(map[string][]*ResolvedAlertSubscription)
-	resolvedAlertSubscriptionsMutex sync.RWMutex
-)
-
-func (s *AlertServiceGorm) addResolvedAlertSubscription(sub *ResolvedAlertSubscription) {
-	resolvedAlertSubscriptionsMutex.Lock()
-	defer resolvedAlertSubscriptionsMutex.Unlock()
-
-	resolvedAlertSubscriptions["global"] = append(resolvedAlertSubscriptions["global"], sub)
-}
-
-func (s *AlertServiceGorm) removeResolvedAlertSubscription(sub *ResolvedAlertSubscription) {
-	resolvedAlertSubscriptionsMutex.Lock()
-	defer resolvedAlertSubscriptionsMutex.Unlock()
-
-	subs := resolvedAlertSubscriptions["global"]
-	for i, s := range subs {
-		if s == sub {
-			resolvedAlertSubscriptions["global"] = append(subs[:i], subs[i+1:]...)
-			break
-		}
-	}
-}
-
-func (s *AlertServiceGorm) broadcastResolvedAlertUpdate(fingerprint string, update *alertpb.ResolvedAlertUpdate) {
-	resolvedAlertSubscriptionsMutex.RLock()
-	defer resolvedAlertSubscriptionsMutex.RUnlock()
-
-	subs := resolvedAlertSubscriptions["global"]
-	for _, sub := range subs {
-		go func(s *ResolvedAlertSubscription) {
-			defer func() {
-				if r := recover(); r != nil {
-					log.Printf("Recovered from panic in resolved alert broadcast: %v", r)
-					close(s.Done)
-				}
-			}()
-
-			if err := s.Stream.Send(update); err != nil {
-				log.Printf("Error sending resolved alert update to subscriber %s: %v", s.SessionID, err)
-				close(s.Done)
-			}
-		}(sub)
-	}
+	return status.Errorf(codes.Unimplemented, "StreamResolvedAlertUpdates is not implemented")
 }
 
 // Helper function to generate secure session ID

--- a/internal/backend/services/stream_resolved_alert_updates_test.go
+++ b/internal/backend/services/stream_resolved_alert_updates_test.go
@@ -1,0 +1,75 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"notificator/config"
+	"notificator/internal/backend/database"
+	alertpb "notificator/internal/backend/proto/alert"
+)
+
+// nopResolvedAlertUpdatesServer implements grpc.ServerStreamingServer[alertpb.ResolvedAlertUpdate]
+// well enough to drive StreamResolvedAlertUpdates in a test, without a real connection.
+type nopResolvedAlertUpdatesServer struct {
+	grpc.ServerStream
+}
+
+func (nopResolvedAlertUpdatesServer) Send(*alertpb.ResolvedAlertUpdate) error { return nil }
+func (nopResolvedAlertUpdatesServer) Context() context.Context               { return context.Background() }
+
+// TestStreamResolvedAlertUpdates_Unimplemented guards against the RPC ever again
+// registering a subscription: nothing in the codebase consumes this stream, and
+// the old per-subscriber-goroutine broadcast could double-close a Done channel
+// and crash the whole backend on a resolution burst after a client disconnected
+// uncleanly (#183). Returning Unimplemented immediately means no subscription is
+// created and no goroutine is left to leak or race.
+func TestStreamResolvedAlertUpdates_Unimplemented(t *testing.T) {
+	db, err := database.NewGormDB("sqlite", config.DatabaseConfig{SQLitePath: t.TempDir() + "/test.db"})
+	if err != nil {
+		t.Fatalf("failed to create test database: %v", err)
+	}
+	if err := db.AutoMigrate(); err != nil {
+		t.Fatalf("failed to migrate test database: %v", err)
+	}
+	svc := NewAlertServiceGorm(db, &config.AdminConfig{})
+
+	err = svc.StreamResolvedAlertUpdates(&alertpb.StreamResolvedAlertUpdatesRequest{SessionId: "irrelevant"}, nopResolvedAlertUpdatesServer{})
+	if status.Code(err) != codes.Unimplemented {
+		t.Fatalf("expected codes.Unimplemented, got: %v", err)
+	}
+}
+
+// TestCreateResolvedAlert_BurstDoesNotCrash is a regression test for the failure
+// scenario in #183: resolving several alerts back to back used to fire one
+// broadcast goroutine per subscriber per call, racing on a dead stream's Done
+// channel. With the subscription machinery removed, a burst of resolutions is
+// just a sequence of DB writes and must succeed without panicking.
+func TestCreateResolvedAlert_BurstDoesNotCrash(t *testing.T) {
+	db, err := database.NewGormDB("sqlite", config.DatabaseConfig{SQLitePath: t.TempDir() + "/test.db"})
+	if err != nil {
+		t.Fatalf("failed to create test database: %v", err)
+	}
+	if err := db.AutoMigrate(); err != nil {
+		t.Fatalf("failed to migrate test database: %v", err)
+	}
+	svc := NewAlertServiceGorm(db, &config.AdminConfig{})
+
+	for i := range 3 {
+		resp, err := svc.CreateResolvedAlert(context.Background(), &alertpb.CreateResolvedAlertRequest{
+			Fingerprint: "fp",
+			Source:      "test",
+			AlertData:   []byte(`{}`),
+		})
+		if err != nil {
+			t.Fatalf("call %d: unexpected error: %v", i, err)
+		}
+		if !resp.Success {
+			t.Fatalf("call %d: expected Success=true, got message: %s", i, resp.Message)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `CreateResolvedAlert` fired one broadcast goroutine per subscriber (`go s.broadcastResolvedAlertUpdate(...)`); when a subscriber's stream was dead, every one of those goroutines raced to `close(s.Done)`. The first close wins, the second panics with `close of closed channel`, and that panic happens *inside* the deferred `recover` — which itself calls `close(s.Done)` again — so it goes unrecovered and kills the backend process.
- `StreamResolvedAlertUpdates` only watched `<-sub.Done`, never `stream.Context().Done()`, so a disconnected client's subscription and handler goroutine stayed registered until the next broadcast tried (and failed) to reach it.
- `grep -r StreamResolvedAlertUpdates internal/webui/` finds no consumer — nothing in the codebase reads this stream — so the fix is deletion rather than a repair: the subscription list/mutex, `add/removeResolvedAlertSubscription`, `broadcastResolvedAlertUpdate`, and the `go s.broadcastResolvedAlertUpdate(...)` call in `CreateResolvedAlert` are removed. `StreamResolvedAlertUpdates` now returns `codes.Unimplemented` and the proto is untouched.
- The sibling `SubscribeToAlertUpdates`/`broadcastUpdate` machinery already watches `stream.Context().Done()` and isn't subject to the double-close crash, so it's left as-is (out of scope for this fix).

Closes #183

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/backend/...` (113 tests)
- [x] Added `TestStreamResolvedAlertUpdates_Unimplemented` — asserts the RPC returns `codes.Unimplemented` and never registers a subscription
- [x] Added `TestCreateResolvedAlert_BurstDoesNotCrash` — regression test for a burst of resolutions (the crash trigger scenario)

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>