### PR TITLE
docs(wiki): sync with recent changes

### DIFF
--- a/openwiki/.last-update.json
+++ b/openwiki/.last-update.json
@@ -1,6 +1,6 @@
 {
-  "updatedAt": "2026-08-01T05:33:10.000Z",
+  "updatedAt": "2026-08-03T05:34:27.000Z",
   "command": "update",
-  "gitHead": "e06b1c464aa8ac3fa0c3b6ae3bd45cbb8539bfcb",
+  "gitHead": "7ec1e5ac8374650e46ef3c471af5a99ea0a19538",
   "model": "claude-sonnet-5"
 }

--- a/openwiki/configuration.md
+++ b/openwiki/configuration.md
@@ -30,7 +30,7 @@ the field a `mapstructure:"<key>"` tag (see `BackendConfig`) or read it explicit
 | Section | Purpose |
 |---------|---------|
 | `alertmanagers[]` | Alertmanager endpoints (name, url, auth, headers, oauth) — see below |
-| `backend` | `grpc_listen`, `grpc_client`, `http_listen`, `database{…}` |
+| `backend` | `grpc_listen`, `grpc_client`, `http_listen`, `database{…}`, `allow_registration` |
 | `backend.database` | `type` (`sqlite`/`postgres`), host/port/name/user/password/ssl_mode, `sqlite_path` |
 | `webui` | `playground` toggle (dev landing page) |
 | `oauth` | OAuth portal config (nilable) — see [OAuth](#oauth) |
@@ -76,6 +76,14 @@ Group sync (`OAUTH_GROUP_SYNC_*`) maps OAuth groups → roles with a cache (defa
 
 > **Reminder:** roles are computed and stored, but **no RPC actually enforces them** today
 > (see [backend](backend.md#auth)).
+
+**Disabling public sign-up:** `backend.allow_registration` (`NOTIFICATOR_BACKEND_ALLOW_REGISTRATION`,
+default `true`) gates classic `Register`/`Login` server-side in `AuthServiceGorm`, independent of
+the WebUI. When `oauth.enabled && oauth.disable_classic_auth`, the backend rejects classic
+auth regardless of this flag — previously that gate only lived in the WebUI's OAuth-config
+fetch and failed open if the fetch errored. `GetOAuthConfig` now returns a server-computed
+`registration_enabled` so `Login.templ` hides the Register link consistently with the
+enforced backend behavior.
 
 ## Sentry {#sentry}
 

--- a/openwiki/dashboard.md
+++ b/openwiki/dashboard.md
@@ -85,6 +85,16 @@ filter-out. See [notifications](notifications.md#what-triggers-a-notification).
 **Adaptive polling** (only when not on SSE, `dashboard_core.templ:506`): every 10 polls it slows
 toward 60s if <10% of polls saw changes, or speeds toward 5s if >50% did.
 
+### Source freshness
+
+`alertCache` (`internal/webui/services/alert_cache.go`) tracks per-Alertmanager `LastSuccessAt`,
+`LastError`, and `ConsecutiveFailures` alongside the cached alerts, updated on every refresh — no
+extra probing. Status is derived, not stored: **unreachable** if the source has never succeeded,
+**stale** at 3+ consecutive failures, otherwise **live**. `GetSourceStatusViews()` embeds this in
+every full dashboard payload and SSE update; the UI shows it as a Sources pill with a popover
+(`components/source_status.templ`, `scripts/dashboard_sources.templ`), a dismissible banner when
+any source is stale/unreachable, and a marker on alerts from a non-live source.
+
 ## Filtering and grouping
 
 Filter dimensions: free-text `searchQuery`; multi-select `severities`, `statuses`, `teams`,
@@ -98,6 +108,11 @@ page, client for SSE/incremental merges.
 
 **Hidden alerts are two-tier:** global per-user hidden alerts/rules (via `hiddenAlertsService`,
 Settings → Hidden tab) *and* filter-scoped hides stored inside a filter preset's `filter_data`.
+Global hides can be **permanent or snoozed**: `UserHiddenAlert.ExpiresAt` (nilable) — nil hides
+forever, a timestamp wakes the alert back up automatically (`GetUserHiddenAlerts` filters on
+`expires_at IS NULL OR expires_at > now()`). The Hidden tab offers duration presets (1h/4h/8h/
+"until tomorrow 9am"/forever), an extend action, and a "wake now" action; a unique index +
+upsert on `(user_id, fingerprint)` prevents duplicate rows when the same alert is re-hidden.
 See [domain](domain.md#collaboration-state-persisted-by-the-backend).
 
 **Grouping** (`viewMode = 'group'`) renders `AlertsGroupView`; the group-by field
@@ -175,6 +190,14 @@ severities, teams, alert names). The page polls every 30s **only while visible**
 event carries a `Kind` (`comment | ack | unack | silence | resolve`) recorded directly by the
 comment/audit write sites; a `comments.Kind` column and a `comments.created_at` index back this.
 
+**@mentions:** comment text is scanned for `@handle` tokens (`static/js/mention_text.js`,
+case-insensitive, self-mentions excluded) and rendered as highlighted links client-side. Server-side,
+`GetRecentActivity` accepts a `mentionsOnly` flag (`?scope=mentions` on `/activity`) that narrows
+the feed to comments mentioning the caller via a `LIKE`-filtered query
+(`internal/backend/database/gorm_db.go:409`); a shared `MentionWindowMinutes` (7 days) bounds both
+the feed and any unread-mentions badge. This is feed/badge only — no push or sound notification
+is triggered by a mention.
+
 ## Alert detail modal
 
 `AlertDetailsModal` (`components/modal_components.templ:921`), opened by
@@ -190,9 +213,15 @@ connected, its comments and acknowledgments.
 Tabs: **Overview**, **Details** (fingerprint, generator URL), **Labels** / **Annotations**
 (copy-to-clipboard), **Acknowledgments**, **Comments** (add/delete; system comments show a badge),
 **History** (lazy `GET /alert/:fp/history` → up to 50 fire/resolve/ack occurrences with MTTR/MTTA),
-and **Sentry** (only if the alert carries a `sentry` annotation/label; lazy-loaded — the target
+**Sentry** (only if the alert carries a `sentry` annotation/label; lazy-loaded — the target
 host is validated against the configured `sentry.base_url` and a mismatch is rejected rather than
-fetched, see [Sentry SSRF fix](#gotchas)). Header offers Silence/Unsilence, configurable per-user
+fetched, see [Sentry SSRF fix](#gotchas)), and **Related** (blast-radius panel,
+`handlers/alert_related.go`): groups other *currently active* alerts (same cache/filter path as
+the main table, so counts match "Filter dashboard on this") that share a label value with the
+open alert. Labels shared by ≤1 other alert or present on ≥90% of active alerts are dropped as
+non-discriminating (`degenerateShareRatio`), and the result is capped at 5 groups of 20 alerts
+each, sorted by group size. No Alertmanager/backend call — cache-only, so it's instant. Header
+offers Silence/Unsilence, configurable per-user
 **annotation buttons**, Ack/Unack, "Source" (`generatorURL`), "Copy as Issue" (builds a Markdown
 issue and copies it), and **"Copy link"** (`copyAlertLink()`, `dashboard_modal.templ:128` — copies
 the same `/dashboard/alert/:fingerprint` deep-link URL used for `pushState`, with a 2s inline

--- a/openwiki/notifications.md
+++ b/openwiki/notifications.md
@@ -48,6 +48,14 @@ Alerts flow through one choke point, `applyIncrementalUpdate(update, source)`
 normalized severity being in `enabledSeverities`. `critical-daytime` is normalized to `critical`
 so it can notify (and gets `requireInteraction`).
 
+**Scoping to a saved filter preset:** `NotificationPreference.NotificationFilterPresetID`
+(empty = all alerts, no scoping) lets a user restrict browser/sound notifications to one saved
+filter preset. `matchesNotificationFilterPreset(alert, filterData)`
+(`static/js/notification_matcher.js`) replays the preset's `filter_data` client-side
+(alertmanagers/severities/statuses/teams/alert_names, plus the preset's own hidden-alert/rule
+checks) before `shouldNotify` fires — the same matching logic the dashboard table uses, so
+"what I see" and "what notifies me" agree when a preset is selected.
+
 **Resolved / flapping alerts re-notify.** When the SSE stream reports an alert removed (a genuine
 Alertmanager resolve), `applyIncrementalUpdate` calls `forgetAlerts()` to evict it from the
 seen-set — so a later re-fire of the same fingerprint notifies again. This eviction is scoped to
@@ -80,7 +88,8 @@ opens the alert detail modal (or navigates to `/dashboard/alert/<fingerprint>`).
 
 Model `NotificationPreference` (`internal/backend/models/notification_preference.go`): one row per
 user (`browser_notifications_enabled` default false, `enabled_severities` JSONB default
-`[critical, warning]`, `sound_notifications_enabled` default true). Path:
+`[critical, warning]`, `sound_notifications_enabled` default true, `notification_filter_preset_id`
+nilable — see scoping above). Path:
 `GET/POST /api/v1/notifications/preferences` (`handlers/notification_handlers.go`) →
 `backendClient` gRPC → `services.go` → `database/notification_db.go`.
 

--- a/openwiki/webui.md
+++ b/openwiki/webui.md
@@ -103,7 +103,10 @@ This is separate from the backend's gRPC collaboration stream — see
   `OAuthCallback`, `Index`, `Playground` (dev/demo landing when `WebUI.Playground` is on),
   `Silences` (`/silences` — creation/preview/extend/expire), `Activity` (`/activity` — the
   cross-alert team activity feed, see [dashboard](dashboard.md#activity-feed)).
-  Browser/sound alerts are covered in [notifications](notifications.md).
+  Browser/sound alerts are covered in [notifications](notifications.md). `Profile`'s account/
+  session stats (acknowledged alerts, comments, color preferences) come from real per-user
+  queries in `profile_handlers.go` / `services.go` — a previous version hardcoded these numbers
+  and its Copy-ID button copied a literal template string instead of the user's actual ID.
 - `components/` — tables, modals, filter/group views, timezone selector, page navigator, etc.
 - `scripts/` — **`.templ` files whose entire body is a `<script>` of hand-written Alpine.js**
   (e.g. `dashboard_core.templ` defines `function newDashboard(){…}`). Included into pages via


### PR DESCRIPTION
Automated openwiki refresh covering:
fix(backend): enforce auth at the gRPC layer (#172)
fix(auth): public registration cannot be disabled and the OAuth-only gate fails open (#169)
fix(webui): snapshot alert before spawning CaptureAlertFired goroutine (#168)
fix(test): set the required service token in CaptureAlertFired snapshot test
feat(dashboard): Alertmanager source freshness — live/stale/unreachable (#170)
feat(notifications): scope browser/sound notifications to a saved filter preset (#158)
feat(dashboard): snooze an alert for a chosen duration instead of forever (#116)
feat(dashboard): blast-radius panel in the alert modal (#174)
feat(collaboration): @mentions in alert comments (#176)
fix(webui): profile page renders fabricated account/session data and its Copy-ID button copies a literal template string (#181)

<!-- doc-agent -->