### PR TITLE
fix(backend): flap guard on resolved alert storage

### DIFF
--- a/internal/backend/database/gorm_db.go
+++ b/internal/backend/database/gorm_db.go
@@ -557,11 +557,11 @@ func (gdb *GormDB) GetAllAcknowledgedAlerts(alertKeys []string) (map[string]mode
 	return result, nil
 }
 
-// isEmptyAcknowledgmentSnapshot reports whether the caller supplied no usable
-// acknowledgment history — either nothing at all, because its fetch failed, or
-// an empty JSON payload.
-func isEmptyAcknowledgmentSnapshot(acknowledgments []byte) bool {
-	switch strings.TrimSpace(string(acknowledgments)) {
+// isEmptyJSONSnapshot reports whether the caller supplied no usable history
+// payload — either nothing at all, because its fetch failed, or an empty JSON
+// payload.
+func isEmptyJSONSnapshot(snapshot []byte) bool {
+	switch strings.TrimSpace(string(snapshot)) {
 	case "", "null", "[]", "{}":
 		return true
 	}
@@ -593,6 +593,15 @@ func snapshotAcknowledgments(tx *gorm.DB, fingerprint string) ([]byte, error) {
 	return snapshot, nil
 }
 
+// resolvedAlertFlapWindow bounds how fast one fingerprint can grow the
+// resolution history: a resolution landing within the window of the previous
+// one refreshes that row instead of inserting a new one. Without it, a
+// flapping alert writes a full JSONB snapshot per flap — 46k alerts expiring
+// and re-firing every ~8 minutes once filled 28 GB in a week.
+// ponytail: fixed window; make it configurable if a deployment needs distinct
+// episodes closer than an hour apart.
+const resolvedAlertFlapWindow = time.Hour
+
 func (gdb *GormDB) CreateResolvedAlert(fingerprint, source string, alertData, comments, acknowledgments []byte, ttlHours int) (*models.ResolvedAlert, error) {
 	now := time.Now()
 	resolvedAlert := &models.ResolvedAlert{
@@ -613,7 +622,7 @@ func (gdb *GormDB) CreateResolvedAlert(fingerprint, source string, alertData, co
 	// may have failed — so the rows are read here when it is missing. Snapshot
 	// and delete then share one transaction and the history cannot be lost.
 	err := gdb.db.Transaction(func(tx *gorm.DB) error {
-		if isEmptyAcknowledgmentSnapshot(acknowledgments) {
+		if isEmptyJSONSnapshot(acknowledgments) {
 			snapshot, err := snapshotAcknowledgments(tx, fingerprint)
 			if err != nil {
 				return err
@@ -622,9 +631,37 @@ func (gdb *GormDB) CreateResolvedAlert(fingerprint, source string, alertData, co
 				resolvedAlert.Acknowledgments = models.JSONB(snapshot)
 			}
 		}
-		if err := tx.Create(resolvedAlert).Error; err != nil {
-			return fmt.Errorf("failed to create resolved alert: %w", err)
+
+		var last models.ResolvedAlert
+		flapErr := tx.Where("fingerprint = ? AND resolved_at > ?", fingerprint, now.Add(-resolvedAlertFlapWindow)).
+			Order("resolved_at DESC").First(&last).Error
+		switch {
+		case flapErr == nil:
+			// Same episode still flapping: refresh the existing row. Comments and
+			// acknowledgments only overwrite when this resolution brought some —
+			// this call's fetch may have failed while an earlier flap captured them.
+			last.AlertData = resolvedAlert.AlertData
+			if !isEmptyJSONSnapshot(resolvedAlert.Comments) {
+				last.Comments = resolvedAlert.Comments
+			}
+			if !isEmptyJSONSnapshot(resolvedAlert.Acknowledgments) {
+				last.Acknowledgments = resolvedAlert.Acknowledgments
+			}
+			last.ResolvedAt = resolvedAlert.ResolvedAt
+			last.ExpiresAt = resolvedAlert.ExpiresAt
+			last.Source = resolvedAlert.Source
+			if err := tx.Save(&last).Error; err != nil {
+				return fmt.Errorf("failed to refresh flapping resolved alert: %w", err)
+			}
+			resolvedAlert = &last
+		case errors.Is(flapErr, gorm.ErrRecordNotFound):
+			if err := tx.Create(resolvedAlert).Error; err != nil {
+				return fmt.Errorf("failed to create resolved alert: %w", err)
+			}
+		default:
+			return fmt.Errorf("failed to check for flapping resolved alert: %w", flapErr)
 		}
+
 		if err := tx.Where("alert_key = ?", fingerprint).Delete(&models.Acknowledgment{}).Error; err != nil {
 			return fmt.Errorf("failed to clear acknowledgments for resolved alert: %w", err)
 		}

--- a/internal/backend/database/gorm_db_test.go
+++ b/internal/backend/database/gorm_db_test.go
@@ -223,6 +223,62 @@ func TestCreateResolvedAlertSnapshotsAcknowledgmentsWhenCallerHasNone(t *testing
 	}
 }
 
+// TestCreateResolvedAlertFlapGuard pins the storage guard against flapping
+// alerts: a resolution landing within resolvedAlertFlapWindow of the previous
+// one for the same fingerprint must refresh that row, not insert a new one,
+// and must not erase comments an earlier flap captured.
+func TestCreateResolvedAlertFlapGuard(t *testing.T) {
+	gdb := newTestDB(t)
+
+	comments := []byte(`[{"username":"alice","content":"seen"}]`)
+	first, err := gdb.CreateResolvedAlert("flappy", "prod", []byte(`{"v":1}`), comments, nil, 24)
+	if err != nil {
+		t.Fatalf("first CreateResolvedAlert: %v", err)
+	}
+
+	second, err := gdb.CreateResolvedAlert("flappy", "prod", []byte(`{"v":2}`), nil, nil, 24)
+	if err != nil {
+		t.Fatalf("second CreateResolvedAlert: %v", err)
+	}
+
+	var count int64
+	if err := gdb.db.Model(&models.ResolvedAlert{}).Where("fingerprint = ?", "flappy").Count(&count).Error; err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("flap within the window must reuse the row, got %d rows", count)
+	}
+	if second.ID != first.ID {
+		t.Errorf("refresh must keep the row identity, got %q then %q", first.ID, second.ID)
+	}
+	if string(second.AlertData) != `{"v":2}` {
+		t.Errorf("refresh must carry the latest alert data, got %q", second.AlertData)
+	}
+	if string(second.Comments) != string(comments) {
+		t.Errorf("refresh without comments must keep the captured ones, got %q", second.Comments)
+	}
+	if second.ResolvedAt.Before(first.ResolvedAt) {
+		t.Errorf("resolved_at must move forward on refresh: %v then %v", first.ResolvedAt, second.ResolvedAt)
+	}
+
+	// Age the episode past the window: the next resolution is a new one.
+	aged := time.Now().Add(-resolvedAlertFlapWindow - time.Minute)
+	if err := gdb.db.Model(&models.ResolvedAlert{}).Where("fingerprint = ?", "flappy").
+		Update("resolved_at", aged).Error; err != nil {
+		t.Fatalf("backdate: %v", err)
+	}
+
+	if _, err := gdb.CreateResolvedAlert("flappy", "prod", []byte(`{"v":3}`), nil, nil, 24); err != nil {
+		t.Fatalf("third CreateResolvedAlert: %v", err)
+	}
+	if err := gdb.db.Model(&models.ResolvedAlert{}).Where("fingerprint = ?", "flappy").Count(&count).Error; err != nil {
+		t.Fatalf("count after window: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("a resolution past the window must start a new row, got %d rows", count)
+	}
+}
+
 // TestCleanupResolvedAcknowledgments covers the startup migration that drops
 // acknowledgment rows orphaned by resolutions that happened before the fix. It
 // re-runs on every boot, so it must keep the acknowledgment of an alert that


### PR DESCRIPTION
## Problem

`resolved_alerts` reached **28 GB / 16.6M rows in 14 days** in production. Investigation showed 6.5M rows/day at peak across only ~49k distinct fingerprints: two Vault lease-expiration alert groups (~46k alerts) expire and re-fire in Alertmanager every ~8 minutes, and every disappearance from the poll writes a full JSONB snapshot row (`CreateResolvedAlert` was an unconditional INSERT — no dedup, 90-day TTL). Left alone this converges to ~700M rows / >1 TB.

## Fix

`CreateResolvedAlert` now checks, inside the existing transaction, for a row of the same fingerprint resolved within the last hour (`resolvedAlertFlapWindow`):

- **Found** → refresh that row (alert_data, resolved_at, expires_at, source) instead of inserting. Comments/acknowledgments only overwrite when the new resolution actually brought some, so history captured by an earlier flap survives a refresh whose own best-effort fetch failed.
- **Not found** → insert as before; resolutions further apart than the window remain distinct history rows.

The acknowledgment snapshot-then-clear lifecycle is unchanged in both paths.

## Testing

- `TestCreateResolvedAlertFlapGuard`: same-fingerprint resolution within the window reuses the row (same ID, latest alert_data, comments preserved, resolved_at advanced); past the window a new row is created.
- Full `./internal/backend/... ./internal/webui/...` suites: 325 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)